### PR TITLE
py_get_samples renovations

### DIFF
--- a/rfmux/algorithms/__init__.py
+++ b/rfmux/algorithms/__init__.py
@@ -1,1 +1,0 @@
-from .measurement import *

--- a/rfmux/core/schema.py
+++ b/rfmux/core/schema.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm.collections import attribute_mapped_collection
 
 from . import hardware_map
 from .hardware_map import Boolean, HWMResource, HWMQuery
-from .streamer import get_samples
+from .streamer import Parser
 
 import sqlalchemy
 from .. import tuber
@@ -197,10 +197,12 @@ class CRS(hardware_map.HWMResource, tuber.TuberObject):
     async def resolve(self):
         await self.tuber_resolve()
 
-    @functools.wraps(get_samples)
-    async def py_get_samples(*args, **kwargs):
-        return await get_samples(*args, **kwargs)
+    @functools.wraps(Parser.get_samples)
+    async def py_get_samples(self, *args, **kwargs):
+        return await Parser(self).get_samples(*args, **kwargs)
 
+    def parser_context(self, *args, **kwargs):
+        return Parser(self, *args, **kwargs)
 
 @ArgumentFiller(
     lambda m: m.crs,

--- a/rfmux/core/schema.py
+++ b/rfmux/core/schema.py
@@ -4,12 +4,15 @@ To specialize a CRS object for a particular experiment, you're
 encouraged to create a subclass.
 """
 
+import functools
+
 from sqlalchemy import Column, Integer, String, ForeignKey, UniqueConstraint, Float
 from sqlalchemy.orm import relationship, backref
 from sqlalchemy.orm.collections import attribute_mapped_collection
 
 from . import hardware_map
 from .hardware_map import Boolean, HWMResource, HWMQuery
+from .streamer import get_samples
 
 import sqlalchemy
 from .. import tuber
@@ -193,6 +196,10 @@ class CRS(hardware_map.HWMResource, tuber.TuberObject):
 
     async def resolve(self):
         await self.tuber_resolve()
+
+    @functools.wraps(get_samples)
+    async def py_get_samples(*args, **kwargs):
+        return await get_samples(*args, **kwargs)
 
 
 @ArgumentFiller(

--- a/rfmux/core/streamer.py
+++ b/rfmux/core/streamer.py
@@ -184,8 +184,9 @@ class Parser:
 
         # Join the multicast group on the specified interface
         mc_ip = socket.inet_aton(STREAMER_HOST)
-        mreq = struct.pack("4s4s", mc_ip, socket.inet_aton(self.multicast_interface_ip))
-        sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+        crs_ip = socket.inet_aton(socket.gethostbyname(crs.tuber_hostname))
+        mreq = struct.pack("4s4s4s", mc_ip, socket.inet_aton(self.multicast_interface_ip), crs_ip)
+        sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_SOURCE_MEMBERSHIP, mreq)
 
         # Set a timeout on the socket to prevent indefinite blocking
         sock.settimeout(5)  # Timeout after 5 seconds


### PR DESCRIPTION
* Re-enables IGMPv3 source-specific multicasting (SSM) - tested and working on my big (TP-Link TL-SG3428X) switch
* Adds a "decorator mode" py_get_samples that can be used as follows:

```
import sys
sys.path.append('/home/gsmecher/crs/rfmux')
import rfmux

import asyncio
import matplotlib.pyplot as plt
import numpy as np

async def test():
    s = rfmux.load_session("!HardwareMap [ !CRS { serial: '0024' } ]")
    d = s.query(rfmux.CRS).one()

    await d.resolve()
    await d.set_timestamp_port(d.TIMESTAMP_PORT.TEST)
    await d.set_frequency(100e6, d.UNITS.HZ, channel=1, module=1)

    async with d.parser_context(channel=1, module=1) as pc:
        for n in range(100):
            await d.set_amplitude(n % 2, d.UNITS.NORMALIZED, d.TARGET.DAC,
                                  channel=1, module=1)
            x = await pc.get_samples(10, stale=True)
            t = -(len(x.i) - 10) + np.arange(len(x.i))
            plt.plot(t, np.abs(np.array(x.i) + 1j*np.array(x.q)))

    plt.grid(True)
    plt.savefig("test_context.png")

asyncio.run(test())
```

I don't think the API is really quite right yet, but I think the idea has merits.