### PR TITLE
Qc revamp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,8 @@ fallback_version = "0.0.0"
 [tool.pytest.ini_options]
 markers = [
   "offline",
+  "qc_stage1",
+  "qc_stage2",
 ]
 
 asyncio_default_fixture_loop_scope = "session"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "tbb; sys_platform != 'darwin'",
 ]
 
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [project.optional-dependencies]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dev = [
   "markdown",
   "nbclient",
   "pytest_check",
-  "reportlab",
   "requests",
   "scikit-learn",
   "weasyprint",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ periscope = "rfmux.tools.periscope.__main__:main"
 
 [dependency-groups]
 dev = [
+  "bs4",
   "htpy",
   "jupytext",
   "markdown",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,3 +66,10 @@ packages = ["rfmux"]
 [tool.setuptools_scm]
 version_file = "rfmux/_version.py"
 fallback_version = "0.0.0"
+
+[tool.pytest.ini_options]
+markers = [
+  "offline",
+]
+
+asyncio_default_fixture_loop_scope = "session"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,19 @@ parser = "rfmux.tools.parser:main"
 [project.gui-scripts]
 periscope = "rfmux.tools.periscope.__main__:main"
 
+[dependency-groups]
+dev = [
+  "htpy",
+  "jupytext",
+  "markdown",
+  "nbclient",
+  "pytest_check",
+  "reportlab",
+  "requests",
+  "scikit-learn",
+  "weasyprint",
+]
+
 [project.urls]
 homepage = "https://github.com/t0/rfmux"
 repository = "https://github.com/t0/rfmux"

--- a/rfmux/core/schema.py
+++ b/rfmux/core/schema.py
@@ -130,7 +130,9 @@ class CRS(hardware_map.HWMResource, tuber.TuberObject):
     def __init__(self, *args, **kwargs):
         if "module" not in kwargs and "modules" not in kwargs:
             self.modules = [ReadoutModule(module=m + 1) for m in range(8)]
-        super().__init__(*args, **kwargs)
+
+        hardware_map.HWMResource.__init__(self, *args, **kwargs)
+        tuber.TuberObject.__init__(self, "Dfmux", hostname=self.tuber_hostname)
 
     @sqlalchemy.orm.reconstructor
     def reconstruct(self):

--- a/test.sh
+++ b/test.sh
@@ -1,45 +1,20 @@
 #!/bin/bash
 
-# Check pre-requisites. Most of these are needed for a complete python build,
-# but it's reasonable to include other ingredients here as well.
-PACKAGES="sqlite3 readline tk libffi liblzma"
-for package in $PACKAGES;
-do
-	if ! pkg-config --exists $package; then
-		echo "Need $package to correctly build a Python environment for testing. Please install it."
-		echo "hint: sudo apt-get install libsqlite3-dev libreadline-dev tk-dev libffi-dev liblzma-dev"
-		exit -1
-	fi
-done
+if ! which -s uv
+then
+	cat <<EOF >&2
+Please install uv! Instructions are available at:
 
-# Get pyenv into our environment, installing if necessary
-if ! command -v pyenv &> /dev/null; then
+	https://docs.astral.sh/uv/getting-started/installation
 
-	if [ ! -e ~/.pyenv ]; then
-		echo "pyenv not found, installing..."
-		# This is alarming - but you're running arbitrary code
-		# regardless, whether we use git or this abomination
-		curl https://pyenv.run | bash
-	fi
+They will tell you to run something like:
 
-	# Add pyenv to PATH (consider adding this to your shell configuration)
-	export PATH="$HOME/.pyenv/bin:$PATH"
-	eval "$(pyenv init --path)"
+	curl -LsSf https://astral.sh/uv/install.sh | sh
+
+You should generally be suspicious of instructions like these.
+EOF
+	exit -1
 fi
 
-# Install necessary Python versions using pyenv
-PYTHON_VERSIONS=("3.10.13" "3.11.8" "3.12.2")
-for version in "${PYTHON_VERSIONS[@]}"; do
-    if ! pyenv versions --bare | grep -q "^$version$"; then
-        pyenv install "$version"
-    fi
-done
-
-# Optionally set a local Python version for the project
-pyenv local 3.10.13 3.11.8 3.12.2
-
-# Ensure tox is installed locally (don't use the distro version)
-pip3.10 install --upgrade pip setuptools tox
-
-# Now kick off regression tests
-python3.10 -m tox
+uv tool install -q tox --with tox-uv
+uv run tox run-parallel

--- a/test/crs_qc/conftest.py
+++ b/test/crs_qc/conftest.py
@@ -153,6 +153,15 @@ async def d(request):
     await d.tuber_resolve()
     await d.set_timestamp_port(d.TIMESTAMP_PORT.TEST)
 
+    # If we're going to be doing low or high banking things, make sure we're
+    # correctly configured. If neither --low-bank or --high-bank were
+    # specified, don't configure anything - any misconfiguration should be
+    # caught by error checks in the on-board C++ code.
+    if low_bank:
+        await d.set_analog_bank(high=False)
+    elif high_bank:
+        await d.set_analog_bank(high=True)
+
     yield d
 
 

--- a/test/crs_qc/conftest.py
+++ b/test/crs_qc/conftest.py
@@ -37,11 +37,11 @@ def pytest_sessionstart(session):
     session.serial = serial
 
     if (results_dir := session.config.getoption("--directory")) is None:
-        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-        day = datetime.datetime.now().strftime("%Y%m%d")
-        results_dir = f"CRS_test_results/{day}/CRS_test_{session.serial}_{timestamp}"
+        raise pytest.UsageError(
+            "--directory not provided! Need to know where to store results."
+        )
+    os.makedirs(results_dir, exist_ok=True)
     session.results_dir = results_dir
-    os.makedirs(session.results_dir, exist_ok=True)
 
     # Initialize shelf file with appropriate structure
     session.shelf_filename = f"{session.results_dir}/qc"
@@ -54,7 +54,7 @@ def pytest_sessionstart(session):
             {
                 # TODO: it would be nice to assemble a list of what tests ran, when
                 "date": datetime.datetime.now(),
-                "args": sys.argv[1:],
+                "args": session.config.invocation_params.args,
                 "logs": [],
             }
         )

--- a/test/crs_qc/conftest.py
+++ b/test/crs_qc/conftest.py
@@ -87,6 +87,25 @@ def shelf(request):
     return shelve.open(request.session.shelf_filename, writeback=True)
 
 
+def pytest_collection_modifyitems(config, items):
+    """
+    When invoked with --high-bank or --low-bank, ensure test IDs reflect it.
+    Otherwise, test IDs overlap between the two runs and data collisions occur.
+    """
+
+    high_bank = config.getoption("--high-bank")
+    low_bank = config.getoption("--low-bank")
+
+    # quirk: because we access these results using sorted(), we want the low
+    # banks to be first in the list. That's why we use 1-3 and 4-8, rather than
+    # "low" and "high" (which come out backwards)
+    for item in items:
+        if high_bank:
+            item._nodeid += "[5-8]"
+        elif low_bank:
+            item._nodeid += "[1-4]"
+
+
 @pytest_asyncio.fixture(scope="function")
 async def d(request):
     """

--- a/test/crs_qc/conftest.py
+++ b/test/crs_qc/conftest.py
@@ -1,127 +1,173 @@
-import sys
-sys.path.append('.')
-
-import pytest
+import datetime
+import matplotlib
 import os
-import json
-from datetime import datetime
-import time
-import rfmux
-import asyncio
-import inspect
+import pytest
 import pytest_asyncio
-from report_generator import generate_report_from_data
+from . import report_generator
+import rfmux
+import shelve
+import subprocess
+import sys
+import pytest_check  # imported to ensure "check" can be used as a fixture
+
+from .crs_qc import ResultTable
+
+matplotlib.use("Agg")  # for non-interactive use
+
+
+def pytest_addoption(parser):
+    # These options all end up determining which ReadoutModules are attached to the CRS
+    parser.addoption("--module", action="store", default=None, type=int)
+    parser.addoption("--modules", action="store", default=None, type=int)
+    parser.addoption("--low-bank", action="store_true", default=None)
+    parser.addoption("--high-bank", action="store_true", default=None)
+
+    # Open a PDF viewer after the test run completes
+    parser.addoption("--view", action="store_true", default=False)
+    parser.addoption("--directory", default=None)
 
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_sessionstart(session):
-    session.user_test_highbank = input("Would you like to run the test on both low (1-4) and high (5-8) banks? Enter Y/N  ")
-    if session.user_test_highbank == 'Y':
-        session.test_highbank = True
-        session.num_runs = 2
-        wait_for_action("Connect the modules 1-8 in loopback.(DAC#--ADC#): (1--1), (2--2), etc. Don't cross connect")
-    else:
-        session.test_highbank = False
-        session.num_runs = 1
-        wait_for_action("Connect the modules 1-4 in loopback.(DAC#--ADC#): (1--1), (2--2), etc. Don't cross connect")
+    # Validate mandatory command-line arguments
+    if (serial := session.config.getoption("--serial")) is None:
+        raise pytest.UsageError(
+            "--serial number not provided! Can't talk to the CRS board."
+        )
+    session.serial = serial
 
-    session.results = {
-        'serial': session.config.getoption("--serial"),
-        'tests': []
-    }
-    session.summary_results = {
-        'serial': session.config.getoption("--serial"),
-        'summary': {}
-    }
-    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-    day = datetime.now().strftime('%Y%m%d')
-    serial = session.config.getoption("--serial")
-    session.results_dir = f'CRS_test_results/{day}/CRS_test_{serial}_{timestamp}'
+    if (results_dir := session.config.getoption("--directory")) is None:
+        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        day = datetime.datetime.now().strftime("%Y%m%d")
+        results_dir = f"CRS_test_results/{day}/CRS_test_{session.serial}_{timestamp}"
+    session.results_dir = results_dir
     os.makedirs(session.results_dir, exist_ok=True)
 
+    # Initialize shelf file with appropriate structure
+    session.shelf_filename = f"{session.results_dir}/qc"
+    with shelve.open(session.shelf_filename, writeback=True) as shelf:
+        shelf["serial"] = serial
+        shelf.setdefault("sections", {})
+        shelf.setdefault("runs", [])
 
-@pytest.fixture(scope="session")
-def serial(pytestconfig):
-    serial = pytestconfig.getoption("--serial")
-    if serial is None:
-        pytest.fail("--serial number not provided! Can't talk to the CRS board.")
-    return serial
+        shelf["runs"].append(
+            {
+                # TODO: it would be nice to assemble a list of what tests ran, when
+                "date": datetime.datetime.now(),
+                "args": sys.argv[1:],
+                "logs": [],
+            }
+        )
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    """
+    Capture a "pass" / "fail" result for each test, and store it in the results shelf.
+    """
+
+    outcome = yield
+    report = outcome.get_result()
+
+    if call.when == "call":
+        with shelve.open(item.session.shelf_filename, writeback=True) as shelf:
+            shelf["runs"][-1]["logs"].append(
+                {
+                    "nodeid": item.nodeid,
+                    "outcome": report.outcome,
+                }
+            )
+
+
+@pytest.fixture(scope="function")
+def shelf(request):
+    """
+    A fixture that allows the results shelf to be accessed from within each test case.
+    """
+    return shelve.open(request.session.shelf_filename, writeback=True)
 
 
 @pytest_asyncio.fixture(scope="function")
-async def d(pytestconfig):
-    serial = pytestconfig.getoption("--serial")
-    if serial is None:
-        pytest.fail("--serial number not provided! Can't talk to the CRS board.")
+async def d(request):
+    """
+    A fixture that provides access to a Dfmux object ("d") from within a test case.
+    """
 
-    hwm = rfmux.load_session(f'!HardwareMap [ !CRS {{serial: "{serial}"}} ]')
+    kwargs = {}
+
+    # Depending on what combination of options (--module, --modules,
+    # --low-bank, --high-bank), instantiate the CRS with the appropriate
+    # ReadoutModules attached.
+
+    module = request.config.getoption("--module")
+    modules = request.config.getoption("--modules")
+    low_bank = request.config.getoption("--low-bank")
+    high_bank = request.config.getoption("--high-bank")
+
+    match (low_bank, high_bank, modules, module):
+        case [None, None, None, None]:
+            # default constructor
+            pass
+
+        case [True, None, None, None]:
+            # low banks only
+            kwargs["modules"] = [rfmux.ReadoutModule(module=m + 1) for m in range(4)]
+
+        case [None, True, None, None]:
+            # high banks only
+            kwargs["modules"] = [rfmux.ReadoutModule(module=m + 5) for m in range(4)]
+
+        case [None, None, int(), None]:
+            # specified bank count
+            if modules < 1 or modules > 8:
+                raise pytest.UsageError(
+                    "--modules argument out of range! Expected 1 <= modules <= 8"
+                )
+            kwargs["modules"] = [
+                rfmux.ReadoutModule(module=m + 1) for m in range(modules)
+            ]
+
+        case [None, None, None, int()]:
+            # specific module index
+            if module < 1 or module > 8:
+                raise pytest.UsageError(
+                    "--module argument out of range! Expected 1 <= module <= 8"
+                )
+            kwargs["modules"] = [rfmux.ReadoutModule(module=module)]
+
+        case _:
+            # confused
+            raise pytest.UsageError(
+                "Unexpected combination of --modules / --module / --low-bank / --high-bank"
+            )
+
+    # Create a HardwareMap - normally, we'd do this through a YAML session
+    # file, but here, we want to control the ReadoutModules associated with it.
+    hwm = rfmux.HardwareMap()
+    hwm.add(rfmux.CRS(serial=request.session.serial, **kwargs))
+    hwm.commit()
+
     d = hwm.query(rfmux.CRS).one()
 
-    # Resolve the device to get all the methods    
-    await d.resolve()
+    # Resolve the device to get all the methods
+    await d.tuber_resolve()
     await d.set_timestamp_port(d.TIMESTAMP_PORT.TEST)
 
-    return d
+    yield d
 
-
-@pytest.fixture(scope="session")
-def user_test_highbank(request):
-    return request.session.user_test_highbank
-
-@pytest.fixture(scope="session")
-def test_highbank(request):
-    return request.session.test_highbank
-
-@pytest.fixture(scope="session")
-def num_runs(request):
-    return request.session.num_runs
-
-@pytest.fixture(scope="session")
-def results_dir(request):
-    return request.session.results_dir
-
-@pytest.fixture(scope="session")
-def results(request):
-    return request.session.results
-
-@pytest.fixture(scope="session")
-def summary_results(request):
-    return request.session.summary_results
 
 @pytest.hookimpl(trylast=True)
 def pytest_sessionfinish(session):
-    results_dir = session.results_dir
-    results = session.results
-    summary_results = session.summary_results
-    results_file = save_results(results, results_dir)
-    summary_file = save_summary_results(summary_results, results_dir)
-    serial = results['serial']
-    generate_report_from_data(serial, results_file, results_dir, summary_file)
+    """After the session completes, assemble (and --view, if requested) a PDF report"""
+    if hasattr(session, "results_dir"):
+        pdf = f"{session.results_dir}/qc.pdf"
 
-def save_results(results, results_dir):
-    results_file = os.path.join(results_dir, 'results.json')
-    with open(results_file, 'w') as file:
-        json.dump(results, file, indent=4)
-    print(f"Results saved to '{results_file}'")  # Debug print
-    return results_file
+        # Generate the report PDF
+        report_generator.main(
+            f"{session.results_dir}", f"{session.results_dir}/qc.html", pdf
+        )
 
-def save_summary_results(summary_results, results_dir):
-    summary_file = os.path.join(results_dir, 'summary_results.json')
-    with open(summary_file, 'w') as file:
-        json.dump(summary_results, file, indent=4)
-    print(f"Summary results saved to '{summary_file}'")
-    return summary_file
-
-@pytest.hookimpl(tryfirst=True)
-def pytest_runtest_setup(item):
-    if item.name == "test_dac_mixmodes":
-        wait_for_action("Please attach the filters to the board before proceeding with the test_dac_mixmodes test.\
-                              \n1st Nyquist filter to ADC#1, \n2nd Nyquist filter to ADC#2,\n3rd Nyquist filter to ADC#3 ")
-
-@pytest.hookimpl(trylast=True)
-def pytest_runtest_teardown(item):
-    if item.name == "test_dac_mixmodes":
-        wait_for_action("Please remove the filters from the board after completing the test_dac_mixmodes test.")
-
-def wait_for_action(action):
-    input(f"{action}\nPress Enter to continue...")
+        # If called with "--view", open it. If this unexpectedly opens gimp, try
+        # $ xdg-mime default org.gnome.Evince.desktop application/pdf
+        if session.config.getoption("view"):
+            subprocess.call(("xdg-open", pdf))

--- a/test/crs_qc/crs_qc.py
+++ b/test/crs_qc/crs_qc.py
@@ -40,7 +40,8 @@ class ResultTable:
             case str():
                 return x
             case _:
-                raise TypeError("Unsupported type")
+                # assume they know what they're doing - might be a htpy native type
+                return x
 
     def __init__(self, *headings):
         self.headings = headings

--- a/test/crs_qc/crs_qc.py
+++ b/test/crs_qc/crs_qc.py
@@ -1,0 +1,77 @@
+import markupsafe
+import markdown
+import htpy
+import textwrap
+
+
+def render_markdown(source):
+    # Documentation contained in the DocString
+    docstring = textwrap.dedent(source)
+    md = markdown.markdown(docstring, extensions=["tables"])
+    doc = markupsafe.Markup(md)
+    return doc
+
+
+class ResultTable:
+    """
+    Renders a table where each row is a "pass/fail" result.
+
+    You instantiate a table with its columns as arguments as follows:
+
+        >>> st = ResultTable("col1", "col2", "col3")
+
+    then populate rows as follows:
+
+        >>> st.pass_("val1", "val2", "val3")  # for "green" results
+        >>> st.fail("val1", "val2", "val3")  # for "red" results
+
+    HTML can then be generated with the __call__ method. Since htpy expects
+    callables, you can passed "st" to htpy directly.
+    """
+
+    @staticmethod
+    def formatter(x):
+        """Default numeric formatter - 3 significant figures for floats"""
+        match x:
+            case int():
+                return f"{x:n}"
+            case float():
+                return f"{x:.03f}"
+            case str():
+                return x
+            case _:
+                raise TypeError("Unsupported type")
+
+    def __init__(self, *headings):
+        self.headings = headings
+        self.entries = []
+        self.classes = []
+
+    def set_formatter(self, formatter):
+        self.formatter = formatter
+
+    def pass_(self, *row):
+        self.entries.append(row)
+        self.classes.append("pass")
+
+    def fail(self, *row):
+        self.entries.append(row)
+        self.classes.append("fail")
+
+    def row(self, *row):
+        self.entries.append(row)
+        self.classes.append(None)
+
+    def __call__(self):
+        return htpy.table[
+            htpy.thead[(htpy.th[c] for c in self.headings)],
+            htpy.tbody[
+                (
+                    htpy.tr[
+                        htpy.td(class_=c)[s],
+                        (htpy.td(class_=c)[v] for v in map(self.formatter, vs)),
+                    ]
+                    for (c, (s, *vs)) in zip(self.classes, self.entries)
+                )
+            ],
+        ]

--- a/test/crs_qc/crs_qc.py
+++ b/test/crs_qc/crs_qc.py
@@ -1,13 +1,29 @@
-import markupsafe
-import markdown
+import base64
+import contextlib
 import htpy
+import io
+import markdown
+import markupsafe
+import matplotlib.figure
 import textwrap
 
 
-def render_markdown(source):
-    # Documentation contained in the DocString
+def render_fig(fig: matplotlib.figure.Figure):
+    """Convert a Figure into an embedded base64-encoded string"""
+    with contextlib.closing(io.BytesIO()) as buf:
+        fig.savefig(buf, format="png")
+        img_base64 = base64.b64encode(buf.getbuffer()).decode()
+        return htpy.img(src=f"data:image/png;base64,{img_base64}")
+
+
+def render_markdown(source: str):
+    """
+    Convert Markdown (in a string) to markupsafe AST nodes
+
+    The declarative HTML library we use (htpy) understands these directly.
+    """
     docstring = textwrap.dedent(source)
-    md = markdown.markdown(docstring, extensions=["tables"])
+    md = markdown.markdown(docstring, extensions=["tables", "attr_list"])
     doc = markupsafe.Markup(md)
     return doc
 

--- a/test/crs_qc/report_generator.py
+++ b/test/crs_qc/report_generator.py
@@ -95,27 +95,25 @@ def main(directory, html_filename, pdf_filename):
                 )
 
         # Generate test results for each run
-        runs = []
+        runs = ResultTable("Run", "Test", "Status")
         for n, run in enumerate(qc["runs"]):
-            rt = ResultTable("Test", "Status")
             for l in run["logs"]:
                 if l["outcome"] == "passed":
-                    rt.pass_(l["nodeid"], "Passed")
+                    runs.pass_(f"{n+1}", l["nodeid"], "Passed")
                 elif l["outcome"] == "failed":
                     # Format failures as a list
                     failures = ul[(li[f] for f in l["failures"])]
-                    rt.fail(l["nodeid"], failures)
+                    runs.fail(f"{n+1}", l["nodeid"], failures)
                 else:
-                    rt.row(l["nodeid"], l["outcome"])
-
-            r = [h3[f"Run {n+1}"], rt]
-            runs.extend(r)
+                    runs.row(f"{n+1}", l["nodeid"], l["outcome"])
 
     # Render document preamble
     preamble = [
         render_markdown(
             f"""
             # CRS QC Test Results: Serial {serial}
+
+            ## Environment
 
             This report was assembled in the following environment:
 
@@ -130,6 +128,8 @@ def main(directory, html_filename, pdf_filename):
             | Python Version | {sys.version} |
             | Pytest Version | {pytest.__version__} |
 
+            ## Runs
+
             This report was assembled from {num_runs} different test runs:
         """
         ),
@@ -138,7 +138,7 @@ def main(directory, html_filename, pdf_filename):
             f"""
             Typically, newer test results replace results from older ones.
 
-            ## Run Summaries
+            ## Run Details
         """
         ),
         runs,

--- a/test/crs_qc/report_generator.py
+++ b/test/crs_qc/report_generator.py
@@ -1,465 +1,165 @@
-import os
+#!/usr/bin/env -S python3
+import argparse
+import datetime
 import json
-import numpy as np
-from datetime import datetime
 import matplotlib.pyplot as plt
-from reportlab.lib.pagesizes import letter
-from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, Image, Table, TableStyle
-from reportlab.lib.styles import getSampleStyleSheet
-from reportlab.lib import colors
-import matplotlib.colors as mcolors
-from reportlab.lib.pagesizes import letter
-from reportlab.lib.units import inch
+import numpy as np
+import os
+import pathlib
+import pytest
+import shelve
+import socket
+import sys
+import warnings
 
-class PDFReport:
-    def __init__(self, serial, results_dir):
-        self.serial = serial
-        self.results_dir = results_dir
-        self.filename = os.path.join(results_dir, f"report_{serial}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.pdf")
-        self.pdf = SimpleDocTemplate(self.filename, pagesize=letter)
-        self.elements = []
-        self.styles = getSampleStyleSheet()
-        self.elements.append(Paragraph(f"Test Report for CRS Board #{serial}", self.styles['Title']))
-        self.elements.append(Paragraph(f"Date: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}", self.styles['Normal']))
+from htpy import (
+    body,
+    h1,
+    h2,
+    h3,
+    head,
+    html,
+    li,
+    link,
+    p,
+    style,
+    table,
+    tbody,
+    td,
+    th,
+    thead,
+    title,
+    tr,
+    ul,
+)
+import weasyprint
 
-    def add_paragraph(self, text, style='Normal'):
-        """Adds a paragraph of text to the document."""
-        self.elements.append(Spacer(1, 12))
-        self.elements.append(Paragraph(text, self.styles[style]))
-
-    def add_section(self, title):
-        self.elements.append(Spacer(1, 12))
-        self.elements.append(Paragraph(title, self.styles['Heading1']))
-
-    def add_plot(self, plot_path, title):
-        self.elements.append(Spacer(1, 12))
-        self.elements.append(Paragraph(title, self.styles['Heading2']))
-        self.elements.append(Image(plot_path, width=450, height=250))
-
-    def add_table(self, table_data, title, custom_style=None, column_width=None):
-        self.elements.append(Spacer(1, 12))
-        self.elements.append(Paragraph(title, self.styles['Heading2']))
-        if column_width:
-            table = Table(table_data, colWidths=column_width)
-        else:
-            table = Table(table_data)
-
-        default_style = TableStyle([
-            ('BACKGROUND', (0, 0), (-1, 0), colors.grey),
-            ('TEXTCOLOR', (0, 0), (-1, 0), colors.whitesmoke),
-            ('ALIGN', (0, 0), (-1, -1), 'CENTER'),
-            ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
-            ('BOTTOMPADDING', (0, 0), (-1, 0), 5),
-            ('BACKGROUND', (0, 1), (-1, -1), colors.white),
-            ('GRID', (0, 0), (-1, -1), 1, colors.black)])
-        
-        if custom_style:
-            table.setStyle(TableStyle(custom_style))
-        else:
-            table.setStyle(default_style)
-
-        self.elements.append(table)
-
-    def save(self):
-        self.pdf.build(self.elements)
-        print(f"PDF report generated: {self.filename}")
-
-    #THIS FUNCTION is only being used by mixmodes (ran out of time to convert it). But ideally the plotting and the saving 
-    #should happend as testing goes on (inside test_crs.py)
-    def plot_data_and_save(self, plot_method, x_set_1, data_set_1, x_set_2 = None, data_set_2=None, label_set_1='measured', label_set_2='predicted', x_label='X-axis', y_label='Y-axis', title='Title', filename='plot.png', scale='linear', yscale='linear', mixmode=False):
-        
-        plt.figure(figsize=(10, 6))
-        colors = list(mcolors.TABLEAU_COLORS.values())
-        reference_color = 'black'
-
-        if mixmode:
-            # Special handling for mixmode data
-            for i, (module, module_data) in enumerate(data_set_1.items()):
-                if i == 0:
-            # Plot the reference data for all modules without the label after the first plot
-                    plt.plot(module_data['reference_frequencies'], module_data['reference_magnitudes'], 'o', label='Reference data', color=reference_color)
-                else:
-                    plt.plot(module_data['reference_frequencies'], module_data['reference_magnitudes'], 'o', color=reference_color)
-
-                plt.scatter(module_data['frequencies'], module_data['magnitudes'], label=f'Module {module}', color=colors[i % len(colors)])
-        else:
-            if plot_method == 'plot':
-                if x_set_1 is not None:
-                    plt.plot(x_set_1, data_set_1, '-o', label=label_set_1)
-                else:
-                    plt.plot(data_set_1, '-o', label=label_set_1)
-
-                if data_set_2 is not None and x_set_2 is not None:
-                    plt.plot(x_set_1, data_set_2, '-o', label=label_set_2)
-
-            elif plot_method == 'scatter':
-                if x_set_1 is not None:
-                    plt.scatter(x_set_1, data_set_1, label=label_set_1)
-                else:
-                    plt.scatter(data_set_1, label=label_set_1)
-
-                if data_set_2  is not None and x_set_2 is not None:
-                    plt.scatter(x_set_1, data_set_2, label=label_set_2)
-
-            elif plot_method == 'plot line':
-                if x_set_1 is not None:
-                    plt.plot(x_set_1, data_set_1, label=label_set_1)
-                else:
-                    plt.plot(data_set_1, label=label_set_1)
-
-                if data_set_2 is not None and x_set_2 is not None:
-                    plt.plot(x_set_2, data_set_2, label=label_set_2)
-
-        plt.xlabel(x_label)
-        plt.xscale(scale)
-        plt.yscale(yscale)
-        plt.ylabel(y_label)
-        plt.legend()
-        plt.title(title)
-        plt.grid(True)
-
-        # Create plot directory
-        plot_path = os.path.join(self.results_dir, 'plots', filename)
-        os.makedirs(os.path.dirname(plot_path), exist_ok=True)
-        plt.savefig(plot_path)
-        plt.tight_layout()
-        plt.close()
-        print(f"Plot saved to: {plot_path}") 
-        return plot_path
-    
-    
-    def generate_summary(self, summary_data):
-        self.add_section('Summary of Test Results')
-
-        # Extract non-module-specific tests from "Board Health"
-        board_health_tests = summary_data['summary'].get('Board Health', {})
-
-        #only create Board Health tests if they were conducted
-        if board_health_tests:  
-            non_module_data = [['Test', 'Status']]
-            for test, status in board_health_tests.items():
-                non_module_data.append([test, status])
-
-            # Use default style for non-module-specific table
-            self.add_table(non_module_data, 'Board health')
+from .crs_qc import render_markdown, ResultTable
 
 
-        # Generate module-specific table data
-        all_tests = sorted(set(test for module, tests in summary_data['summary'].items() if module.isdigit() for test in tests))
-        module_specific_data = [['Module'] + all_tests]
+def main(directory, html_filename, pdf_filename):
+    # Retrieve sections from shelf
+    with shelve.open((pathlib.Path(directory) / "qc").as_posix()) as qc:
+        serial = qc["serial"]
 
-        for module, tests in summary_data['summary'].items():
-            if not module.isdigit():
-                continue  # Skip non-module-specific tests
-            row = [module] + [tests.get(test, 'N/A') for test in all_tests]
-            module_specific_data.append(row)
-        
-        page_width = letter[0] - 2 * inch  # Letter page width minus 2 inches of margins (1 inch on each side)
-        num_columns = len(module_specific_data[0])
-        column_width = [page_width / num_columns] * num_columns
+        sections = sorted(qc["sections"].keys())
+        elements = [qc["sections"][k] for k in sections]
 
+        # Generate run table
+        rt_runs = ResultTable(
+            "Run", "Date", "Arguments", "Passed", "Failed", "Tests Executed"
+        )
+        num_runs = len(qc["runs"])
 
-        # Style for module-specific table
-        pastel_green = colors.Color(0.85, 1.0, 0.85)
-        pastel_red = colors.Color(1.0, 0.85, 0.85)
-        style = [
-            ('BACKGROUND', (0, 0), (-1, 0), colors.grey),
-            ('TEXTCOLOR', (0, 0), (-1, 0), colors.whitesmoke),
-            ('ALIGN', (0, 0), (-1, -1), 'CENTER'),
-            ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
-            ('BOTTOMPADDING', (0, 0), (-1, 0), 5),
-            ('GRID', (0, 0), (-1, -1), 1, colors.black),
-        ]
+        for n, run in enumerate(qc["runs"]):
 
-        for row_index, row in enumerate(module_specific_data[1:], start=1):  # Skip header row
-            for col_index, cell in enumerate(row[1:], start=1):  # Skip module column
-                if cell == 'Pass':
-                    style.append(('BACKGROUND', (col_index, row_index), (col_index, row_index), pastel_green))
-                elif cell == 'Fail':
-                    style.append(('BACKGROUND', (col_index, row_index), (col_index, row_index), pastel_red))
+            outcomes = [x["outcome"] for x in run["logs"]]
+            passed = list(map(lambda x: x == "passed", outcomes))
+            failed = list(map(lambda x: x == "failed", outcomes))
 
-        if len(module_specific_data) > 1:  # Only add the table if there are module-specific tests
-            self.add_table(module_specific_data, 'Summary of Module Tests', custom_style=style, column_width=column_width)
-
-    
-    
-    def generate_temperature_section(self, data):
-        self.add_section('Temperature Test')
-
-        table_data = [['Sensor', 'Temperature (C)']] + list(zip(data['sensors'], data['temperatures']))
-        self.add_table(table_data, 'Sensor Temperatures')
-
-    def generate_voltage_section(self, data):
-        self.add_section('Voltage Test')
-        rounded_measured_voltage = [round(x, 2) for x in data['voltages']]
-
-        table_data = [['Sensor', 'Voltage (V)']] + list(zip(data['sensors'], rounded_measured_voltage))
-        self.add_table(table_data, 'Sensor Voltages')
-
-    def generate_current_section(self, data):
-        self.add_section('Current Test')
-        rounded_measured_currents = [round(x, 2) for x in data['currents']]
-
-        table_data = [['Sensor', 'Current (A)']] + list(zip(data['sensors'], rounded_measured_currents))
-        self.add_table(table_data, 'Sensor Currents')
-
-
-
-    def generate_dac_passband_section(self, data):
-        self.add_section('DAC Passband Test')
-        self.add_paragraph('This test aims to determine if the DAC accurately produces signals of frequencies within its passband (550MHz). \
-                            A flat passband is expected within 275MHz relative to the NCO \
-                           and the measured magnitudes will be compared to the reference values. The following measurement is taken at NCO = 625MHz, \
-                           with Amplitude  = 0.001, and Scale = 7. This test has capacity to set and measure 1000 channels simultaneously, so you can adjust the density of the points directly in the script')
-
-
-        for module in data['modules']:
-            self.add_plot(f'{module["plot_path"]}', f'DAC passband at module {module["module"]}')
-
-            if module['error']:
-                self.add_paragraph(f'Module {module["module"]} does not meet the flat passband requirement.\
-                                    {module["error"]}')
-            else:
-                self.add_paragraph(f'Module {module["module"]} meets the passband requirements')
-
-    def generate_dac_amplitude_transfer_section(self, data):
-            self.add_section('DAC Amplitude Transfer Test')
-            self.add_paragraph('This test aims to determine if the DAC accurately scales the output signal with an increase in amplitude. \
-                            The setting of amplitude is internal to the FPGA and represents the fraction of power outputted by the dac.\
-                            The relationship is expected to be logarithmic and is predicted with a DAC Transfer function')
-
-            for module in data['modules']:
-                self.add_plot(f'{module["plot_path"]}', f'Signal power vs normalized amplitude at module {module["module"]}')
-
-                if module['error']:
-                    self.add_paragraph(f'Module {module["module"]} does not scale its output with amplitude correctly.\
-                                    {module["error"]}')
-                else:
-                    self.add_paragraph(f'Module {module["module"]} meets the amplitude scaling requirements')
-
-                '''
-                If want to add a table, add only select values, NOT like this
-                rounded_measured_dbm = [round(x, 2) for x in module['magnitude_dbm_values']]
-                rounded_predicted_dbm = [round(x, 2) for x in module['predicted_magnitude_dbm_values']]
-                table_data = [['Amplitude', 'Pass/Fail', 'Measured (dBm)', 'Predicted (dBm)']] + \
-                            list(zip(module['amplitude_values'], \
-                                    ['Pass' if 0.9*predicted > abs(measured) > 1.1 *predicted  else 'Fail' \
-                                    for measured, predicted in zip(rounded_measured_dbm, rounded_predicted_dbm)],
-                                    rounded_measured_dbm,\
-                                    rounded_predicted_dbm))
-                self.add_table(table_data, f'Magnitude vs Amplitude at module {module["module"]}')
-                '''
-        
-    def generate_dac_scale_transfer_section(self, data):
-        self.add_section('DAC Scale Transfer Test')
-        self.add_paragraph('Following the test of amplitude scaling, this test will determine if the DAC converter\
-                           outputs signals of expected power level. The test will repeatedly call set_dac_scale with increasing values., which\
-                            will change the current input into the balun. We expect the power output to scale linearly')
-
-        for module in data['modules']:
-            self.add_plot(f'{module["plot_path"]}', f'Magnitude vs scale at module {module["module"]}')
-            
-            rounded_measured_dbm = [round(x, 2) for x in module['magnitude_dbm_values']]
-            rounded_predicted_dbm = [round(x, 2) for x in module['predicted_magnitude_dbm_values']]
-            table_data = [['Scale', 'Pass/Fail', 'Measured (dBm)', 'Predicted (dBm)']] + \
-                         list(zip(module['scale_values'], \
-                                  ['Pass' if abs(measured - predicted) < 3  else 'Fail' \
-                                   for measured, predicted in zip(rounded_measured_dbm, rounded_predicted_dbm)],
-                                   rounded_measured_dbm,\
-                                   rounded_predicted_dbm))
-            self.add_table(table_data, f'Magnitude vs Scale Table at module {module["module"]}')
-
-    
-    def generate_dac_mixmode_section(self, data):
-        self.add_section(f'DAC in Mixmode 1 and 2 {data["analog_bank"]} bank')
-        if data['analog_bank'] == 'low':
-            self.add_paragraph('This test aims to determine if the DAC accurately produces signals when a particular mixmode is set.\
-                                Following the selected configuration of module-filter, we obtain the data for a single Nyquist region from a corresponding module.\
-                                The graphs of the mixmodes shown below are stitched together from the 3 measurements to showcase the complete behavior of the system.\
-                                Furthermore, data from the benchtop measurement is used to gauge the expected power output. The expected shapes should be consistent with \
-                                NRZ mode in the first mixmode and RC mode in the second mixmode.')
-
-        # Initialize the data structure for both banks
-        combined_data = {
-            'low': {1: {}, 2: {}},
-            'high': {1: {}, 2: {}}
-        }
-
-        # Aggregate data for each mixmode and module, separated by bank
-        for mixmode in data['mixmodes']:
-            mode = mixmode['mixmode']
-            module = mixmode['module']
-            bank = data['analog_bank']  # Determine if it's low or high bank
-
-            if module not in combined_data[bank][mode]:
-                combined_data[bank][mode][module] = {
-                    'frequencies': [],
-                    'magnitudes': [],
-                    'reference_frequencies': [],
-                    'reference_magnitudes': []
-                }
-
-            combined_data[bank][mode][module]['frequencies'].extend(mixmode['frequencies'])
-            combined_data[bank][mode][module]['magnitudes'].extend(mixmode['magnitude_dbm_values'])
-            combined_data[bank][mode][module]['reference_frequencies'].extend(mixmode['reference_frequencies'])
-            combined_data[bank][mode][module]['reference_magnitudes'].extend(mixmode['reference_magnitudes'])
-
-        # Plot data for each mixmode and bank
-        for bank_name in ['low', 'high']:
-            for mode in combined_data[bank_name]:
-                if not combined_data[bank_name][mode]:
-                    continue  # Skip if no data for this bank and mixmode
-
-                # The combined data for all modules in this bank and mixmode
-                data_set_1 = combined_data[bank_name][mode]
-
-                plot_path = self.plot_data_and_save(
-                    plot_method='scatter',
-                    x_set_1=None,  # This is None because the data is in the dictionary
-                    data_set_1=data_set_1,  # Pass the dictionary directly
-                    x_set_2=None,  # No need to pass this if you're handling references separately
-                    data_set_2=None,
-                    label_set_1='Measured Frequencies',
-                    label_set_2='Reference Frequencies',
-                    x_label='Frequency (GHz)',
-                    y_label='Signal Magnitude (dBm)',
-                    title=f'DAC output in mixmode #{mode} for {bank_name} bank',
-                    filename=f'DAC_output_in_mixmode_{mode}_{bank_name}.png',
-                    mixmode=True
+            if all(passed):
+                rt_runs.pass_(
+                    f"{n+1}",
+                    f'{run["date"].strftime("%Y-%m-%d %H:%M:%S")}',
+                    f'{" ".join(run["args"])}',
+                    sum(passed),
+                    sum(failed),
+                    len(outcomes),
                 )
-                self.add_plot(plot_path, f'Signal power vs normalized amplitude in Mixmode #{mode} for {bank_name} bank')
-
-
-
-    
-    def generate_adc_attenuation_section(self, data):
-        self.add_section('ADC Attenuation Test')
-        self.add_paragraph('This test aims to determine if the attenuation factor set at the ADC \
-                           accurately scales the incoming signal and is consistent with the predictions from the ADC transfer function. \
-                           The internal mechanics of this test are mirror images of the scale test above.\
-                           The test repeatedly calls set_adc_attenuation() with increasing factors, which changes the current input to the balun.\
-                           A linear relationship is expected.')
-
-        for module in data['modules']:
-            self.add_plot(f'{module["plot_path"]}', f'Magnitude vs attenuation at module {module["module"]}')
-
-            rounded_measured_dbm = [round(x, 2) for x in module['magnitude_dbm_values']]
-            rounded_predicted_dbm = [round(x, 2) for x in module['predicted_magnitude_dbm_values']]
-            table_data = [['Attenuation', 'Pass/Fail', 'Measured (dBm)', 'Predicted (dBm)']] + \
-                         list(zip(module['attenuation_values'], \
-                                  ['Pass' if abs(measured - predicted) < 1  else 'Fail' \
-                                   for measured, predicted in zip(rounded_measured_dbm, rounded_predicted_dbm)],
-                                   rounded_measured_dbm,\
-                                   rounded_predicted_dbm))
-            self.add_table(table_data, f'Magnitude vs Attenuation Table at module {module["module"]}')
-
-
-    def generate_loopback_noise_section(self, data):
-        self.add_section('Loopback Noise Test')
-        self.add_paragraph('Firstly, to study the noise environment, a pure noise measurement will be taken. Setting carrier amplitude\
-                            to 0 and calculating the PSD from the ADC samples yields the first graph. The expectation of the mean whilte noise level \
-                           is 163dBm +- 5 percent.')
-        self.add_paragraph('Secondly, we study the noise behaviour when it is entirely dominate by 1/f slope. The fitting should reveal the \
-                           factor of n = -1 within an acceptable margin (now what IS that margin, still need to set).')
-
-
-        for module in data['modules']:
-
-            '''
-            UNDER CONSTRUCTION. Need to add NCR calculation, use more channels, and have a graph that has a complete\
-                            fit with the 1/f AND the noise floor (very close on that, figuring out final quirks of the fitting).
-            '''
-            self.add_plot(f'{module["plot_path_white"]}', f'Noise floor in loopback at module {module["module"]}')
-                    
-            if any(noise > -140 for noise in module['psd_i_white']) or any(noise > -140 for noise in module['psd_q_white']):
-                self.add_paragraph(f'FAIL: module {module["module"]} produces exessive noise >-140dBm')
-
+            elif any(failed):
+                rt_runs.fail(
+                    f"{n+1}",
+                    f'{run["date"].strftime("%Y-%m-%d %H:%M:%S")}',
+                    f'{" ".join(run["args"])}',
+                    sum(passed),
+                    sum(failed),
+                    len(outcomes),
+                )
             else:
-                self.add_paragraph(f'PASS: noise from module {module["module"]} is within expected bounds <-140dBm')
+                rt_runs.row(
+                    f"{n+1}",
+                    f'{run["date"].strftime("%Y-%m-%d %H:%M:%S")}',
+                    f'{" ".join(run["args"])}',
+                    sum(passed),
+                    sum(failed),
+                    len(outcomes),
+                )
 
-            self.add_plot(f'{module["plot_path_1_f"]}', f'IQ Standard deviation at module {module["module"]}')
-            expected_slope = -1
-            if abs((module['slope'] - expected_slope) / expected_slope) > 0.1:
-                self.add_paragraph("Observe the slope of the 1/f noise deviates from the expected value of -1 (insert potential reason why).")
+        # Generate test results for each run
+        runs = []
+        for n, run in enumerate(qc["runs"]):
+            rt = ResultTable("Test", "Status")
+            for l in run["logs"]:
+                if l["outcome"] == "passed":
+                    rt.pass_(l["nodeid"], "Passed")
+                elif l["outcome"] == "failed":
+                    rt.fail(l["nodeid"], "Failed")
+                else:
+                    rt.row(l["nodeid"], l["outcome"])
 
-    def generate_wideband_fft_section(self, data):
-        self.add_section('Wideband FFT')
-        self.add_paragraph('Performed a 60000 sample measurement and took a snapshot fft of the target band 0 - 2.5GHz (Nyquist)\
-                            to get an FFT with frequency resolution of 83kHz. The values on the units are a little nuts though')
+            r = [h3[f"Run {n+1}"], rt]
+            runs.extend(r)
 
-        for module in data['modules']:
-            self.add_plot(f'{module["plot_path"]}', f'Wideband FFT in loopback at module {module["module"]}')
+    # Render document preamble
+    preamble = [
+        render_markdown(
+            f"""
+            # CRS QC Test Results: Serial {serial}
 
+            This report was assembled in the following environment:
 
-def generate_report_from_data(serial, data_file, results_dir, summary_file):
-    with open(data_file, 'r') as file:
-        data = json.load(file)
-        
-    with open(summary_file, 'r') as file:
-        summary_data = json.load(file)
+            | Item  | Value |
+            | ----  | ----- |
+            | CRS Serial | {serial} |
+            | Date/Time  | {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')} |
+            | Hostname | {socket.gethostname()} |
+            | User | {os.environ["USER"]} |
+            | Python Executable | {sys.argv[0]} |
+            | Python Arguments | {' '.join(sys.argv[1:])} |
+            | Python Version | {sys.version} |
+            | Pytest Version | {pytest.__version__} |
 
-    report = PDFReport(serial, results_dir)
+            This report was assembled from {num_runs} different test runs:
+        """
+        ),
+        rt_runs,
+        render_markdown(
+            f"""
+            Typically, newer test results replace results from older ones.
 
-    # Add summary section
-    report.generate_summary(summary_data)
+            ## Run Summaries
+        """
+        ),
+        runs,
+    ]
 
-    for section in data['tests']:
-        if section['title'] == 'Summary of Results':
-            report.generate_summary(section)
-        if section['title'] == 'Temperature Test':
-            report.generate_temperature_section(section)
-        elif section['title'] == 'Voltage Test':
-            report.generate_voltage_section(section)
-        elif section['title'] == 'Current Test':
-            report.generate_current_section(section)
-        elif section['title'] == 'Loopback Noise Test':
-            report.generate_loopback_noise_section(section)
-        elif section['title'] == 'DAC Scale Transfer Test':
-            report.generate_dac_scale_transfer_section(section)
-        elif section['title'] == 'DAC Amplitude Transfer Test':
-            report.generate_dac_amplitude_transfer_section(section)
-        elif section['title'].startswith('DAC Mixmodes Test'):
-            report.generate_dac_mixmode_section(section)
-        elif section['title'] == 'ADC Attenuation Test':
-            report.generate_adc_attenuation_section(section)
-        elif section['title'] == 'DAC Passband Test':
-            report.generate_dac_passband_section(section)
-        elif section['title'] == 'Wideband FFT for Noise Detection':
-            report.generate_wideband_fft_section(section)
+    # Assemble document
+    doc = html[
+        head[title[f"CRS QC Test Results: Board CRS{serial}"]],
+        preamble,
+        body[elements],
+    ]
+    encoded = doc.encode()
 
-        #elif section['title'] == 'ADC Even Phase Test':
-            # report.generate_adc_even_phase_section(section)
+    # Save HTML if requested
+    if html_filename is not None:
+        with open(html_filename, "wb") as f:
+            f.write(encoded)
 
-    report.save()
-
-
-    '''
-    def generate_adc_even_phase_section(self, data):
-        self.add_section('ADC Even Phase Test')
-        self.add_paragraph('To complete the evalution of the noise performance, raw I and Q samples will\
-                           be plotted on a scatter plot. The readout is expected to have to have equal amplitude and phase noise\
-                           resulting in a circular scatter plot. However, in the past this has been proven difficult with a dominant amplitude noise.')
+    # Save PDF
+    w = weasyprint.HTML(string=encoded, base_url=directory)
+    css_path = pathlib.Path(__file__).parent / "style.css"
+    w.write_pdf(pdf_filename, stylesheets=[weasyprint.CSS(css_path.as_posix())])
 
 
-        for module in data['modules']:
-            plot_path = self.plot_data_and_save('scatter',
-                module['data_i_samples'],
-                module['data_q_samples'],
-                None,
-                'Measured at ADC SMA',
-                'predicted = none',
-                'I (Normalized)',
-                'Q (Normalized))',
-                f'I vs Q Scatter Plot for Module {module["module"]}',
-                f'I vs Q Scatter Plot for Module {module["module"]}.png'
-            )
-            self.add_plot(plot_path, f'I vs Q Noise at module {module["module"]}')
-            
-            if np.isclose(module['ratio'], 1, atol=0.1):
-                self.add_paragraph(f'The signal at module {module["module"]} has balanced I-Q noise')
-            else:
-                self.add_paragraph(f'The signal at module {module["module"]} has scewed I-Q components')
-
-            #table_data = [['Eigenvalue Ratio']] + [[module['ratio']]]
-            #self.add_table(table_data, f'Eigenvalue Ratio for Module {module["module"]}')
-    '''
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="generate_report",
+        description="Generate a PDF version of the QC test run",
+        conflict_handler="resolve",
+    )
+    parser.add_argument("-d", "--directory", default=".")
+    parser.add_argument("--html", default=None)  # can't override -h
+    parser.add_argument("-p", "--pdf", default="qc.pdf")
+    args = parser.parse_args()
+    main(args.directory, args.html, args.pdf)

--- a/test/crs_qc/report_generator.py
+++ b/test/crs_qc/report_generator.py
@@ -102,7 +102,9 @@ def main(directory, html_filename, pdf_filename):
                 if l["outcome"] == "passed":
                     rt.pass_(l["nodeid"], "Passed")
                 elif l["outcome"] == "failed":
-                    rt.fail(l["nodeid"], "Failed")
+                    # Format failures as a list
+                    failures = ul[(li[f] for f in l["failures"])]
+                    rt.fail(l["nodeid"], failures)
                 else:
                     rt.row(l["nodeid"], l["outcome"])
 
@@ -141,7 +143,7 @@ def main(directory, html_filename, pdf_filename):
         ),
         runs,
         h2["Table of Contents"],
-        div(id='toc'),
+        div(id="toc"),
     ]
 
     # Assemble document

--- a/test/crs_qc/report_generator.py
+++ b/test/crs_qc/report_generator.py
@@ -38,7 +38,12 @@ from htpy import (
 )
 import weasyprint
 
-from .crs_qc import render_markdown, ResultTable
+try:
+    # when imported from conftest.py, we need package-relative imports
+    from .crs_qc import render_markdown, ResultTable
+except ImportError:
+    # when invoked separately, we need a straight import
+    from crs_qc import render_markdown, ResultTable
 
 
 def main(directory, html_filename, pdf_filename):

--- a/test/crs_qc/run_qc.py
+++ b/test/crs_qc/run_qc.py
@@ -1,26 +1,68 @@
 #!/usr/bin/env -S uv run python3
+"""
+Usage: run_qc.py --serial=0033 [QC arguments...] [pytest arguments...]
 
-import pytest
-import sys
+This is the recommend point-of-entry for QC runs. You should invoke this script
+as follows:
+
+    $ ./run_qc.py --serial=0033
+
+This script accepts any arguments pytest understands (try "pytest --help for
+details). Here are a few useful examples:
+
+    -x: abort testing after the first failure
+    -s: don't suppress stdout/stderr
+    -v: verbose (or "-vv" for more verbose)
+    -k EXPRESSION: select which tests are executed
+
+This script also understands a few QC-specific options:
+
+    --view: launch a PDF viewer after completing the QC run
+    --serial SERIAL: this is how you tell the QC script which CRS to use
+    --directory DIRECTORY: collect outputs in DIRECTORY
+"""
+
+import argparse
 import datetime
 import pathlib
-import argparse
+import pytest
+import subprocess
+import sys
 
 if __name__ == "__main__":
+    # We're going to invoke pytest and, at very least, want to point it to this
+    # script's path (so it discovers the right conftest.py and QC tests.)
     qc_path = pathlib.Path(__file__).parent
-    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-    day = datetime.datetime.now().strftime("%Y%m%d")
-    results_dir = f"CRS_test_results/{day}/CRS_test_{timestamp}"
+    base_args = sys.argv[1:] + [qc_path.as_posix()]
 
-    base_args = sys.argv[1:] + [
-        qc_path.as_posix(),
-        "--directory",
-        results_dir,
-    ]
+    if "--serial" not in base_args and not any(
+        arg.startswith("--serial=") for arg in base_args
+    ):
+        # We require, at very least, a --serial argument.
+        print(sys.modules[__name__].__doc__)
+        sys.exit(1)
+
+    if "--directory" not in base_args and not any(
+        arg.startswith("--directory") for arg in base_args
+    ):
+        # If --directory wasn't provided, invent one.
+        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        day = datetime.datetime.now().strftime("%Y%m%d")
+        results_dir = f"CRS_test_results/{day}/CRS_test_{timestamp}"
+        base_args.extend(["--directory", results_dir])
+
+    if launch_viewer := "--view" in base_args:
+        # Intercept --view so we don't open several work-in-progress PDFs
+        base_args.remove("--view")
 
     # Stage-1 tests have no particular filter requirements
     pytest.main(base_args + ["-m", "qc_stage1"])
 
-    # Stage-2 tests require XYZ
+    # Stage-2 tests require loopback cables
     pytest.main(base_args + ["-m", "qc_stage2", "--low-bank"])
     pytest.main(base_args + ["-m", "qc_stage2", "--high-bank"])
+
+    # If called with "--view", open it. If this unexpectedly opens gimp, try
+    # $ xdg-mime default org.gnome.Evince.desktop application/pdf
+    if launch_viewer:
+        subprocess.Popen(("xdg-open", f"{results_dir}/qc.pdf"), start_new_session=True)

--- a/test/crs_qc/run_qc.py
+++ b/test/crs_qc/run_qc.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env -S uv run python3
+
+import pytest
+import sys
+import datetime
+import pathlib
+import argparse
+
+if __name__ == "__main__":
+    qc_path = pathlib.Path(__file__).parent
+    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    day = datetime.datetime.now().strftime("%Y%m%d")
+    results_dir = f"CRS_test_results/{day}/CRS_test_{timestamp}"
+
+    base_args = sys.argv[1:] + [
+        qc_path.as_posix(),
+        "--directory",
+        results_dir,
+    ]
+
+    # Stage-1 tests have no particular filter requirements
+    pytest.main(base_args + ["-m", "qc_stage1"])
+
+    # Stage-2 tests require XYZ
+    pytest.main(base_args + ["-m", "qc_stage2", "--low-bank"])
+    pytest.main(base_args + ["-m", "qc_stage2", "--high-bank"])

--- a/test/crs_qc/style.css
+++ b/test/crs_qc/style.css
@@ -52,23 +52,30 @@ td.fail { background-color: #ffcdd2; }
 
 /* Images: centered, scaled */
 figure {
-	display: inline-block;
-	margin: 0 auto;
+    display: inline-block;
+    margin: 0 auto;
 }
 figure img {
-	margin: 0 auto;
-	vertical-align: top;
-	max-width: 60%;
-	display: block;
-	height: auto;
+    margin: 0 auto;
+    vertical-align: top;
+    max-width: 60%;
+    display: block;
+    height: auto;
 }
 figure figcaption {
-	text-align: center;
-	font-weight: bold;
+    text-align: center;
+    font-weight: bold;
 }
 
 /* lists */
 ul, ol {
-	list-style-position: inside;
-	margin-left: 1.5em; padding-left: 1.5em; }
+    list-style-position: inside;
+    margin-left: 1.5em; padding-left: 1.5em;
+}
+
+/* For the table of contents, add page number links */
+#toc {
+    a::after {
+        content: ' ' leader('.') ' ' target-counter(attr(href), page);
+    }
 }

--- a/test/crs_qc/style.css
+++ b/test/crs_qc/style.css
@@ -4,21 +4,28 @@
     padding: 0;
     box-sizing: border-box;
 }
+
 body {
     font-family: 'Lato', sans-serif;
-    font-size: 10px;
-    line-height: 1.4;
+    font-size: 11px;
+    line-height: 1.5;
     color: #333;
+    padding-bottom: 1em;
 }
+
 h1, h2, h3, h4, h5, h6 {
     font-family: 'Montserrat', sans-serif;
     font-weight: 700;
     color: #222;
-    margin-top: 1em;
-    margin-bottom: 0.5em;    /* Reduced spacing for compactness */
+    margin-top: 1.2em;
+    margin-bottom: 1em;
 }
+h1 {
+    border-bottom: 2px solid #ccc;
+}
+
 p {
-  margin-bottom: 0.75em;   /* Slight spacing between paragraphs */
+  margin-bottom: 1em;
 }
 
 /* Links */
@@ -30,13 +37,14 @@ a:hover { text-decoration: underline; }
 
 /* Tables: centered */
 table {
-    margin: 0 auto;
-    border: 1px solid #000;
+    margin: 1em auto;
+    border: 1px solid #ccc;
     border-collapse: collapse;
+    width: 90%;
 }
 th, td {
-    border: 1px solid #000;
-    padding: 4px;
+    border: 1px solid #222;
+    padding: 6px;
 }
 th {
     text-align: center;    
@@ -52,8 +60,9 @@ td.fail { background-color: #ffcdd2; }
 
 /* Images: centered, scaled */
 figure {
-    display: inline-block;
-    margin: 0 auto;
+    display: block;
+    margin: 1em auto;
+    text-align: center;
 }
 figure img {
     margin: 0 auto;
@@ -70,12 +79,35 @@ figure figcaption {
 /* lists */
 ul, ol {
     list-style-position: inside;
-    margin-left: 1.5em; padding-left: 1.5em;
+    margin-left: 1.5em;
+    padding-left: 1.5em;
+    text-indent: -1.5em;
 }
 
-/* For the table of contents, add page number links */
-#toc {
-    a::after {
-        content: ' ' leader('.') ' ' target-counter(attr(href), page);
+/* Page header/footer */
+@page {
+    margin: 1in;
+
+    /* Header */
+    @top-center {
+        content: "CRS Quality Control (QC) Report";
+	font-size: 12px;
+	font-family: 'Montserrat', sans-serif;
     }
+
+    /* Footer */
+    @bottom-center {
+        content: "Page " counter(page) " / " counter(pages);
+	font-size: 12px;
+	font-family: 'Montserrat', sans-serif;
+	color: #222;
+    }
+}
+
+/* Suppress header on first page */
+@page :first { @top-center { content: none; } }
+
+/* For the table of contents, add page number links */
+#toc a::after {
+    content: ' ' leader('.') ' ' target-counter(attr(href), page);
 }

--- a/test/crs_qc/style.css
+++ b/test/crs_qc/style.css
@@ -57,6 +57,11 @@ td {
 }
 td.pass { background-color: #c8e6c9; }
 td.fail { background-color: #ffcdd2; }
+tr {
+    /* Discourage splitting cells across page breaks */
+    page-break-inside: avoid;
+    break-inside: avoid;
+}
 
 /* Images: centered, scaled */
 figure {

--- a/test/crs_qc/test_crs.py
+++ b/test/crs_qc/test_crs.py
@@ -78,6 +78,7 @@ def covariance_matrix(samples):
 """-------------------------------------------DAC--------------------------------------------------------------"""
 
 
+@pytest.mark.qc_stage2
 @pytest.mark.asyncio
 async def test_dac_passband(d, request, shelf, check):
     """
@@ -198,6 +199,7 @@ async def test_dac_passband(d, request, shelf, check):
         x["sections"][request.node.name] = render
 
 
+@pytest.mark.qc_stage2
 @pytest.mark.asyncio
 async def test_dac_amplitude_transfer(d, request, shelf, check):
     """
@@ -305,6 +307,7 @@ async def test_dac_amplitude_transfer(d, request, shelf, check):
         x["sections"][request.node.name] = render
 
 
+@pytest.mark.qc_stage2
 @pytest.mark.asyncio
 async def test_dac_scale_transfer(d, request, shelf, check):
     """
@@ -424,6 +427,7 @@ async def test_dac_scale_transfer(d, request, shelf, check):
 
 
 @pytest.mark.xfail
+@pytest.mark.qc_stage2
 @pytest.mark.asyncio
 async def test_dac_mixmodes(d, results, summary_results, test_highbank):
     """
@@ -609,6 +613,7 @@ async def test_dac_mixmodes(d, results, summary_results, test_highbank):
 
 
 @pytest.mark.xfail
+@pytest.mark.qc_stage2
 @pytest.mark.asyncio
 async def test_adc_attenuation(
     d, results, summary_results, test_highbank, num_runs, results_dir
@@ -726,6 +731,7 @@ async def test_adc_attenuation(
 
 
 @pytest.mark.skip(reason="no way of currently testing this")
+@pytest.mark.qc_stage2
 @pytest.mark.asyncio
 async def test_adc_even_phase(d, results):
     AMPLITUDE = 0.1
@@ -764,6 +770,7 @@ async def test_adc_even_phase(d, results):
         print("The cluster is more oval in shape.")
 
 
+@pytest.mark.qc_stage2
 @pytest.mark.asyncio
 async def test_wideband_noise(d, request, shelf, check):
     """

--- a/test/crs_qc/test_crs.py
+++ b/test/crs_qc/test_crs.py
@@ -196,7 +196,7 @@ async def test_dac_passband(d, request, shelf, check):
         )
 
     with shelf as x:
-        x["sections"][request.node.name] = render
+        x["sections"][request.node.nodeid] = render
 
 
 @pytest.mark.qc_stage2
@@ -222,7 +222,7 @@ async def test_dac_amplitude_transfer(d, request, shelf, check):
 
     # feel free to adjust the amplitude density as needed
     amplitudes = np.arange(0.05, 1, 0.05)
-    d.clear_channels()
+    await d.clear_channels()
 
     for m in d.modules:
         module_errors = []
@@ -304,7 +304,7 @@ async def test_dac_amplitude_transfer(d, request, shelf, check):
         )
 
     with shelf as x:
-        x["sections"][request.node.name] = render
+        x["sections"][request.node.nodeid] = render
 
 
 @pytest.mark.qc_stage2
@@ -423,7 +423,7 @@ async def test_dac_scale_transfer(d, request, shelf, check):
         )
 
     with shelf as x:
-        x["sections"][request.node.name] = render
+        x["sections"][request.node.nodeid] = render
 
 
 @pytest.mark.xfail
@@ -636,7 +636,7 @@ async def test_adc_attenuation(
             magnitude_dbm_values = []
             predicted_magnitude_dbm_values = []
 
-            d.clear_channels()
+            await d.clear_channels()
             await value_setter_helper(
                 d,
                 FREQUENCY,
@@ -829,4 +829,4 @@ async def test_wideband_noise(d, request, shelf, check):
         )
 
     with shelf as x:
-        x["sections"][request.node.name] = render
+        x["sections"][request.node.nodeid] = render

--- a/test/crs_qc/test_crs.py
+++ b/test/crs_qc/test_crs.py
@@ -1,417 +1,215 @@
 #!/usr/bin/env -S pytest-3 -s
-'''
-Welcome to the CRS QC framework. You should invoke these tests as follows:
+"""
+Datapath tests
 
-    $ pytest test_crs_integrated.py --serial=<serial> -s
+Please see README for hints on using and extending these test cases.
+"""
 
-If you wish to run only a set of particular tests:
-
-    $ pytest test_crs.py --serial=<serial> -k "<test_test_name_1> or <test_name_2>"
-'''
-
+import htpy
 import os
 import pytest
 import rfmux
 import time
 import numpy as np
-import matplotlib
 import matplotlib.pyplot as plt
-import socket
-import requests
 
+from .crs_qc import render_markdown, ResultTable
 from scipy import signal
 from scipy.stats import linregress
 from sklearn.linear_model import LinearRegression
 from sklearn.metrics import r2_score
-from conftest import wait_for_action
 
-matplotlib.use('Agg')  # Set the backend to 'Agg' for non-interactive use
 
-# Ensure network can resolve the board. Does not use rfmux.
-def test_can_resolve_crs(request, results):
-    '''Can we resolve a CRS board?
-
-    This is a basic "is the board alive, and is the network functioning" check.
-    It doesn't rely on rfmux because we want to slowly assemble faith in a
-    working set-up and produce the most informative error messages possible if
-    something breaks.
-    '''
-
-    hostname = f'rfmux{request.config.getoption("--serial")}.local'
-
-    # 1. Can we resolve the board?
-    try:
-        address = socket.gethostbyname(hostname)
-    except Exception as e:
-        raise IOError(f"Unable to resolve hostname {hostname}!") from e
-
-    # 2. Can we make a bare/empty HTTP request to it?
-    try:
-        text = requests.post(f'http://{hostname}/tuber', data="[]").text
-    except Exception as e:
-        raise IOError("Unable to invoke basic call with CRS via HTTP POST!") from e
-    assert text == '[]'
-
-    results['tests'].append({
-        'title': 'Board Communications Test',
-        'status': 'OK'
-    })
-
-@pytest.mark.asyncio
-async def test_multicast_reception(d):
-    x = await d.py_get_samples(1, module=1, channel=1)
-   
-'''-------------------------------------HELPER FUNCTIONS---------------------------------------------'''
 def transfer_function_helper(raw_sampl, AMPLITUDE, scale, attenuation):
-    '''
+    """
     Calculates the dBm value of a sample from get_samples call.
     Predicts the dBm value of the signal from the parameters passed to it
-    '''
+    """
     DB_LOSS_FACTOR = -2.56
-    volts_peak_samples = (np.sqrt(2)) * np.sqrt(50 * (10 ** (-1.75 / 10)) / 1000) / 1880796.4604246316
+    volts_peak_samples = (
+        (np.sqrt(2)) * np.sqrt(50 * (10 ** (-1.75 / 10)) / 1000) / 1880796.4604246316
+    )
     if np.iscomplexobj(raw_sampl):
         data_i = np.array(raw_sampl.real) * volts_peak_samples
         data_q = np.array(raw_sampl.imag) * volts_peak_samples
     else:
         data_i = np.array(raw_sampl.i) * volts_peak_samples
         data_q = np.array(raw_sampl.q) * volts_peak_samples
-    magnitude = np.sqrt(data_i ** 2 + data_q ** 2)
+    magnitude = np.sqrt(data_i**2 + data_q**2)
     median_magnitude = np.median(magnitude)
-    median_magnitude_dbm = 10 * np.log10(((median_magnitude / np.sqrt(2)) ** 2) / 50) + 30
+    median_magnitude_dbm = (
+        10 * np.log10(((median_magnitude / np.sqrt(2)) ** 2) / 50) + 30
+    )
 
-    DAC_output_dBm = DB_LOSS_FACTOR + 10 * np.log10((AMPLITUDE ** 2) * 10 ** (scale / 10))
+    DAC_output_dBm = DB_LOSS_FACTOR + 10 * np.log10((AMPLITUDE**2) * 10 ** (scale / 10))
     predicted_magnitude_dbm = DAC_output_dBm - attenuation
     return median_magnitude_dbm, predicted_magnitude_dbm
 
-def value_setter_helper(d, frequency, amplitude, scale, attenuation, channel, module, nco):
-    '''
+
+async def value_setter_helper(
+    d, frequency, amplitude, scale, attenuation, channel, module, nco
+):
+    """
 
     NOTE: All the tests below are written with the following numbering conventions for highbanks
     set_amplitude, set_frequency, get_samples, set_nyqist_zone -- accept module 1-4
-    set_scale, set_attenuation, set_nco -- accept module 1-8 
-    
-    '''
+    set_scale, set_attenuation, set_nco -- accept module 1-8
 
-    d.clear_channels()
-    d.set_frequency(frequency, channel, module)
-    d.set_amplitude(amplitude, d.UNITS.NORMALIZED, channel, module)
-    d.set_dac_scale(scale, d.UNITS.DBM, module)
-    d.set_adc_attenuator(attenuation, d.UNITS.DB, module=module)
+    """
 
-#small legacy helper used in checking how circular the i-q blob is
+    async with d.tuber_context() as ctx:
+        ctx.clear_channels()
+        ctx.set_frequency(frequency, channel, module)
+        ctx.set_amplitude(amplitude, d.UNITS.NORMALIZED, channel, module)
+        ctx.set_dac_scale(scale, d.UNITS.DBM, module)
+        ctx.set_adc_attenuator(attenuation, d.UNITS.DB, module=module)
+        ctx.set_nco_frequency(nco, module=module)
+
+
+# small legacy helper used in checking how circular the i-q blob is
 def covariance_matrix(samples):
     cov_matrix = np.cov(samples, rowvar=False)
     eigenvalues, _ = np.linalg.eigh(cov_matrix)
     ratio = eigenvalues[1] / eigenvalues[0]
     return ratio
-'''------------------------------------------------------------------------------------------------------------'''
-'''-------------------------------------------SENSORS--------------------------------------------------------------'''
-@pytest.mark.asyncio
-async def test_temperature(d, results, summary_results):
-    TEMPERATURE_MIN = 0.0
-    TEMPERATURE_MAX = 70.0
-    errors = []
-    test_status = 'Pass'
 
-    sensors = (
-        d.TEMPERATURE_SENSOR.MB_R5V0,
-        d.TEMPERATURE_SENSOR.MB_R3V3A,
-        d.TEMPERATURE_SENSOR.MB_R2V5,
-        d.TEMPERATURE_SENSOR.MB_R1V8,
-        d.TEMPERATURE_SENSOR.MB_R1V2A,
-        d.TEMPERATURE_SENSOR.MB_R1V4,
-        d.TEMPERATURE_SENSOR.MB_R1V2B,
-        d.TEMPERATURE_SENSOR.MB_R0V85A, 
-        d.TEMPERATURE_SENSOR.MB_R0V85B, 
-        d.TEMPERATURE_SENSOR.RFSOC_PL, 
-        d.TEMPERATURE_SENSOR.RFSOC_PS,
-    )
-    async with d.tuber_context() as ctx:
-        for s in sensors:
-            ctx.get_motherboard_temperature(s)
-        temps = await ctx()
-    for (s, v) in zip(sensors, temps):
-        if not (TEMPERATURE_MIN <= v <= TEMPERATURE_MAX):
-            errors.append(f"Sensor {s} with value {v} out of range {TEMPERATURE_MIN}, {TEMPERATURE_MAX}!")
-            test_status = 'Fail'
-        print(f"Temperature for sensor {s}: {v}")
-    results['tests'].append({
-        'title': 'Temperature Test',
-        'sensors': [str(sensor) for sensor in sensors],
-        'temperatures': temps,
-        'errors': errors,
-        'test_status': test_status
-    })
-    if 'Board Health' not in summary_results['summary']:
-        summary_results['summary']['Board Health'] = {}
-    summary_results['summary']['Board Health']['Temperature Test'] = test_status
+
+"""------------------------------------------------------------------------------------------------------------"""
+"""-------------------------------------------DAC--------------------------------------------------------------"""
+
 
 @pytest.mark.asyncio
-async def test_voltages(d, results,summary_results):
+async def test_dac_passband(d, request, shelf, check):
+    """
+    ## DAC Passband Checks
 
-    VOLTAGE_TOL = 0.10  # 10%
-    test_status = 'Pass'
-    sensors = (
-        (d.VOLTAGE_SENSOR.MB_VBP, 12),  # power supply
-        (d.VOLTAGE_SENSOR.MB_R0V85A, 0.85),#
-        (d.VOLTAGE_SENSOR.MB_R0V85B, 0.85),#
-        (d.VOLTAGE_SENSOR.MB_R1V2A, 1.2),#
-        (d.VOLTAGE_SENSOR.MB_R1V2B, 1.2),#
-        (d.VOLTAGE_SENSOR.MB_R1V4, 1.4),#
-        (d.VOLTAGE_SENSOR.MB_R1V8A, 1.8),#
-        (d.VOLTAGE_SENSOR.MB_R2V5, 2.5),#
-        (d.VOLTAGE_SENSOR.MB_R3V3A, 3.3),#
-        (d.VOLTAGE_SENSOR.MB_R5V0, 5.0),#
-        (d.VOLTAGE_SENSOR.RFSOC_PSMGTRAVCC, 0.9), #seen in in rfsoc_power
-        (d.VOLTAGE_SENSOR.RFSOC_PSMGTRAVTT, 1.8), #CONFUSION top right in in rfsoc_power says 1.2 but acc output 1.8
-        (d.VOLTAGE_SENSOR.RFSOC_VCCAMS, 1.8), # CONFUSION found VCCINTAMS - 0.85. but need a diff one
-        (d.VOLTAGE_SENSOR.RFSOC_VCCAUX, 1.8), #in rfsoc_power
-        (d.VOLTAGE_SENSOR.RFSOC_VCCBRAM, 0.85),# seen in rfsoc_power.sch
-        (d.VOLTAGE_SENSOR.RFSOC_VCCINT, 0.85), #seen in rfsoc_power.sch
-        (d.VOLTAGE_SENSOR.RFSOC_VCCPLAUX, 1.8), #
-        (d.VOLTAGE_SENSOR.RFSOC_VCCPLINTFP, 0.85),#in rfsoc_power
-        (d.VOLTAGE_SENSOR.RFSOC_VCCPLINTLP, 0.85),#in rfsoc_power
-        (d.VOLTAGE_SENSOR.RFSOC_VCCPSAUX, 1.8),#in rfsoc_power
-        (d.VOLTAGE_SENSOR.RFSOC_VCCPSDDR, 1.2), #
-        (d.VOLTAGE_SENSOR.RFSOC_VCCPSINTFP, 0.85),#in rfsoc_power
-        (d.VOLTAGE_SENSOR.RFSOC_VCCPSINTFPDDR, 0.85),#in rfsoc_power
-        (d.VOLTAGE_SENSOR.RFSOC_VCCPSINTLP, 0.85), #in rfsoc_power
-        (d.VOLTAGE_SENSOR.RFSOC_VCCPSIO0, 1.8),
-        (d.VOLTAGE_SENSOR.RFSOC_VCCPSIO1, 3.3),
-        (d.VOLTAGE_SENSOR.RFSOC_VCCPSIO2, 3.3),
-        (d.VOLTAGE_SENSOR.RFSOC_VCCPSIO3, 3.3),
-        (d.VOLTAGE_SENSOR.RFSOC_VCCVREFN, 0),
-        (d.VOLTAGE_SENSOR.RFSOC_VCCVREFP, 1.85),
-        (d.VOLTAGE_SENSOR.RFSOC_VCC_PSBATT, 0),#this is grounded as seen in rfsoc_power
-        (d.VOLTAGE_SENSOR.RFSOC_VCC_PSDDRPLL, 1.8),# in rfsoc_power
-        (d.VOLTAGE_SENSOR.RFSOC_VCC_PSPLL0, 1.2),# in rfsoc_power
-    )
-    #Get the real time data from sensors and check if it's within 10% of the allowed
-    async with d.tuber_context() as ctx:
-        for (s, nv) in sensors:
-            ctx.get_motherboard_voltage(s)
-        voltages = await ctx()
-    for ((s, nv), v) in zip(sensors, voltages):
-        min_v = nv * (1 - VOLTAGE_TOL)
-        max_v = nv * (1 + VOLTAGE_TOL)
+    Validate:
 
-        if  round(v, 2) <min_v or round(v, 2)> max_v:
-            print(f"Sensor {s} with value {v} out of range {min_v}, {max_v}!")
-            test_status = 'Fail'
-        print(f"Voltage for sensor {s}: {v}")
-
-    results['tests'].append({
-        'title': 'Voltage Test',
-        'sensors': [str(sensor[0]) for sensor in sensors],
-        'voltages': voltages,
-        'test_status': test_status
-    })
-
-    if 'Board Health' not in summary_results['summary']:
-        summary_results['summary']['Board Health'] = {}
-    summary_results['summary']['Board Health']['Voltage Test'] = test_status
-
-@pytest.mark.asyncio
-async def test_currents(d, results, summary_results):
-    CURRENT_LIMIT = 0.4  # 40% tolerance on the current limit
-    test_status = 'Pass'
-    sensors = (
-        (d.CURRENT_SENSOR.MB_R0V85A, 2.5),
-        (d.CURRENT_SENSOR.MB_R0V85B, 3.3),
-        (d.CURRENT_SENSOR.MB_R1V2A, 2.4),
-        (d.CURRENT_SENSOR.MB_R1V2B, 2.6),
-        (d.CURRENT_SENSOR.MB_R1V4, 3.6),
-        (d.CURRENT_SENSOR.MB_R1V8A, 3.3),
-        (d.CURRENT_SENSOR.MB_R2V5, 4.1),
-        (d.CURRENT_SENSOR.MB_R3V3A, 3.4),
-        (d.CURRENT_SENSOR.MB_R5V0, 4.1),
-        (d.CURRENT_SENSOR.MB_VBP, 4),
-    )
-    async with d.tuber_context() as ctx:
-        for (s, nc) in sensors:
-            ctx.get_motherboard_current(s)
-        currents = await ctx()
-    for ((s, nc), v) in zip(sensors, currents):
-        min_c = nc * (1 - CURRENT_LIMIT)
-        max_c = nc * (1 + CURRENT_LIMIT)
-        if v > max_c:
-            print(f"Sensor {s} with value {v} A above {max_c}!")
-        if v < min_c:
-            print(f"Sensor {s} with value {v} A below {min_c}!")
-
-            test_status = 'Fail'
-        print(f"Current for sensor {s}: {v}")
-    results['tests'].append({
-        'title': 'Current Test',
-        'sensors': [str(sensor[0]) for sensor in sensors],
-        'currents': currents,
-        'test_status': test_status
-    })
-    if 'Board Health' not in summary_results['summary']:
-        summary_results['summary']['Board Health'] = {}
-    summary_results['summary']['Board Health']['Current Test'] = test_status
-'''------------------------------------------------------------------------------------------------------------'''
-'''-------------------------------------------DAC--------------------------------------------------------------'''
-@pytest.mark.asyncio
-async def test_dac_passband(d, results, summary_results, num_runs, test_highbank, results_dir):
-
-    '''This test aims to determine 2 things: if the magnitude of the output signal from the DAC 
-    is within expected margin and if the passband stays flat throughout the predicted frequency range (-300 -- 300) wrt the NCO.
-
-    The algorithm takes the length of'frequencies' array to determine how many channels to set. If the frequencies array is >1000
-    items, it records that repetitions of the process are needed (num_runs). NOTE: feel free to adjust the frequencies array to your 
-    desired density. 
-    Then, the 1000 channels are set to the amplitudes and frequencies -300 -- 300. Recorded sample magnitude is compared to the 
-    predicted magnitude (predicted from the transfer functions). 
-     
-    0 Hz frequency is taken as reference. If recorded magnitude is >10% off from predicted -- fail. If the measured data on either side 
-    of the 0Hz deviates by more than 3dB from center freuqency -- fail.
-    
-    AMPLITUDE - Intentionally chosed to be 0.001 to be able to set 1000 channels at once without exceeding the full scale
-    NCO_FREQUENCY - Can be changed if desired. Was chosen as 625e6 to gauge module performance comparing it to old, measured data. 
-    NOMINAL_AMPLITUDE, NOMINAL_FREQUENCY - are there to help set the attenuation, scale for each module, are completely nominal, can you any number.
-
-    '''
+    * Amplitude variation is less than 6 dB from nominal across the passband
+    """
+    render = [render_markdown(test_dac_passband.__doc__)]
 
     # FIXME: Some issue with the higher range of the frequencies showing a dip
-    AMPLITUDE = 0.005 # FIXME: JM change by x5
+    AMPLITUDE = 0.005
     SAMPLES = 10
-    NCO_FREQUENCY = 1e9+123
+    NCO_FREQUENCY = 1e9 + 123
     ATTENUATION = 0
     SCALE = 7
-    NOMINAL_AMPLITUDE = 0.5
-    NOMINAL_FREQUENCY = 200e6
-    NOMINAL_CHANNEL = 1
-    TITLE = 'DAC Passband Test'
+
+    MARGIN_DBM = 6
 
     # Feel free to increase the range and density of frequencies
-    frequencies = np.arange(-250e6, 250e6, 10e6)
+    frequencies = np.arange(-250e6, 250e6, step=1e6)
     channels = np.arange(1, 1001)
     nruns = int(np.ceil(len(frequencies) / len(channels)))
     lenrun = min(len(frequencies), len(channels))
-    test_result = {
-        'title': TITLE,
-        'modules': []
-    }
 
-    #always start with the lowbanks. This will only change to True (and algorithm will repeat) if the passed test_highbank ==True
-    highbank_run = False
+    # Set all parameters that won't change: attenuation, scale, NCO
+    async with d.tuber_context() as ctx:
+        ctx.clear_channels()
+        for module in d.modules:
+            ctx.set_dac_scale(SCALE, d.UNITS.DBM, module=module.module)
+            ctx.set_adc_attenuator(ATTENUATION, d.UNITS.DB, module=module.module)
+            ctx.set_nco_frequency(NCO_FREQUENCY, module=module.module)
 
-    #num_runs passed from the config file depending on whether or not there will be a highbank run
-    for num_run in range(0, num_runs):
-        for module in range(1, 5):
+    # Serialize the test over each module
+    for m in d.modules:
 
-            #used for saving data in the dictionary under correct number (while being able to set values and get samples following the current conventions)
-            module_actual = module
-            
-            if highbank_run:
-                module_actual +=4
+        measured_dbm = np.zeros_like(frequencies)
+        predicted_dbm = np.zeros_like(frequencies)
 
-            print(f'DAC_passband - Testing Module #:{module_actual}')
-            
-            measured_dbm = []
-            predicted_dbm = []
-            module_errors = []
-            for nrun in range(nruns):
-                start_idx = nrun * lenrun
-                end_idx = min(start_idx + lenrun, len(frequencies))
-                d.clear_channels()
-                time.sleep(0.2)
+        for nrun in range(nruns):
+            start_idx = nrun * lenrun
+            end_idx = min(start_idx + lenrun, len(frequencies))
+            time.sleep(0.2)
 
-                #First, call the function to set all the parameters that won't change: attenuation, scale, nco
-                value_setter_helper(d, NOMINAL_FREQUENCY,NOMINAL_AMPLITUDE, SCALE, ATTENUATION, NOMINAL_CHANNEL, module, NCO_FREQUENCY)
-                
-                async with d.tuber_context() as ctx:
-                    #Set all the nessesary channels for the run
-                    for idx in range(start_idx, end_idx):
-                        channel = int(channels[idx - start_idx])  # Convert to int and access correct channel
-                        frequency = float(frequencies[idx])  # Convert to float
-                        ctx.set_frequency(frequency, channel, module)
-                        ctx.set_amplitude(AMPLITUDE, d.UNITS.NORMALIZED, channel, module)
-                    await ctx()
-                time.sleep(0.2)
-
-                # Get all the samples for the current run
-                raw = await d.py_get_samples(SAMPLES, channel=None, module=module)
-
+            # Set necessary channels for the run
+            async with d.tuber_context() as ctx:
                 for idx in range(start_idx, end_idx):
-                    channel = int(channels[idx - start_idx])  # Convert to int and access correct channel
-                    rchan = np.array(raw.i[channel+1])+1j*np.array(raw.q[channel+1])
-                    frequency = float(frequencies[idx])  # Ensure frequency is a float
-                    measured, predicted = transfer_function_helper(rchan, AMPLITUDE, SCALE, ATTENUATION)
-                    measured_dbm.append((frequency, measured))
-                    predicted_dbm.append((frequency, predicted))
+                    channel = int(channels[idx - start_idx])
+                    ctx.set_frequency(frequencies[idx], channel, module=m.module)
+                    ctx.set_amplitude(
+                        AMPLITUDE, d.UNITS.NORMALIZED, channel, module=m.module
+                    )
+                for idx in range(end_idx, start_idx + lenrun):
+                    ctx.set_amplitude(0, d.UNITS.NORMALIZED, channel, module=m.module)
 
-            mag_0 = next(meas for freq, meas in measured_dbm if freq == 0)
-            
-            #if 10% error from predicted -- fail
-            if mag_0 < 1.1*predicted or mag_0 > 0.9*predicted:
-                error = f"At a reference frequency (625MHz), generating a power output >10% off from predicted. Expected value is: {predicted}. Measured value was: {mag_0:.2f}"
-                print(error)
-                module_errors.append(error)
+            # Get all the samples for the current run
+            raw = await d.py_get_samples(SAMPLES, channel=None, module=m.module)
 
-            #if 3dBm from predicted -- fail
-            for freq, meas in measured_dbm:
-                if abs(freq) <= 275e6 and meas <= mag_0 - 3:
-                    error = f"Taking 0Hz as reference, there are significant gaps in the passband.Generating signals below -3dB point relative to 0Hz."
-                    print(error)
-                    module_errors.append(error)
-                    break
+            for idx in range(start_idx, end_idx):
+                channel = int(channels[idx - start_idx])
+                rchan = np.array(raw.i[channel + 1]) + 1j * np.array(raw.q[channel + 1])
+                measured, predicted = transfer_function_helper(
+                    rchan, AMPLITUDE, SCALE, ATTENUATION
+                )
+                measured_dbm[idx] = measured
+                predicted_dbm[idx] = predicted
 
-            if not module_errors:
-                print(f'Module {module_actual} passed the test')   
+        mag_0 = measured_dbm[np.argmin(np.abs(frequencies))]
 
-            module_result = {
-                'module': module_actual,  # Ensure this is an int
-                'frequencies': [freq/ 1e6 for freq, _ in measured_dbm],  # Convert frequencies to float
-                'measured_dbm': [meas for _, meas in measured_dbm],  # Ensure this is a float
-                'predicted_magnitude_dbm_values': [predicted for _, predicted in predicted_dbm],  # Convert to a list of floats
-                'status': 'Fail' if module_errors else 'Pass',
-                'error': '\n'.join(module_errors),
-                'plot_path': 'plot_path'
-            }
+        rt = ResultTable("Metric", "Measurement", "Nominal", "Minimum", "Maximum")
 
-            #Determine the graph name / address for the plot (will be accessed in report_generator)
-            graph_name = TITLE + "_module_"+ f'{module_result["module"]}' +'.png'
-            plot_path = os.path.join(results_dir, 'plots', graph_name)
-            module_result["plot_path"] = plot_path
-            
-            plt.figure(figsize=(10, 6))
-            plt.plot(module_result['frequencies'], module_result['measured_dbm'], '-o', label = 'measured' )
-            plt.plot(module_result['frequencies'], module_result['predicted_magnitude_dbm_values'], '-o', label = 'predicted' )
-            plt.xlabel('Frequency (MHz)')
-            plt.ylabel('Magnitude (dBm)')
-            plt.legend()
-            plt.title(f'Signal at DAC of module {module_result["module"]} with increasing frequency')
-            plt.grid(True)
-            plt.tight_layout()
-            os.makedirs(os.path.dirname(plot_path), exist_ok=True)
-            plt.savefig(plot_path)
-            plt.close()
-            
+        if check.between(mag_0, mag_0 - MARGIN_DBM, mag_0 + MARGIN_DBM):
+            rt.pass_(
+                "Gain at NCO Centre",
+                f"{mag_0:.1f} dBm",
+                f"{predicted:.1f} dBm",
+                f"{predicted-MARGIN_DBM:.1f} dBm",
+                f"{predicted+MARGIN_DBM:.1f} dBm",
+            )
+        else:
+            rt.fail(
+                "Gain at NCO Centre",
+                f"{mag_0:.1f} dBm",
+                f"{predicted:.1f} dBm",
+                f"{predicted-MARGIN_DBM:.1f} dBm",
+                f"{predicted+MARGIN_DBM:.1f} dBm",
+            )
 
-            test_result['modules'].append(module_result)
+        errors = np.abs(measured_dbm - predicted) > MARGIN_DBM
+        check.is_false(any(errors))
 
-            if module_actual not in summary_results['summary']:
-                summary_results['summary'][module_actual] = {}
-            summary_results['summary'][module_actual]['Passband'] = module_result['status']
+        plt.figure(figsize=(10, 6))
+        plt.plot(frequencies, measured_dbm, "-,", label="measured")
+        plt.plot(frequencies[errors], measured_dbm[errors], "ro", fillstyle="none")
+        plt.plot(frequencies, predicted_dbm, "-,", label="predicted")
+        plt.xlabel("Frequency (MHz)")
+        plt.ylabel("Magnitude (dBm)")
+        plt.legend()
+        # plt.title(f'Signal at DAC of module {m.module} with increasing frequency')
+        plt.grid(True)
+        plt.tight_layout()
+        plt.savefig(f"{request.session.results_dir}/{request.node.name}-{m.module}.png")
+        plt.close()
 
-        #after 1 ru is complete, determine if a second run is needed
-        if test_highbank:
-            d.set_analog_bank(True)
-            highbank_run = True
-    
-    d.set_analog_bank(False)
-    results['tests'].append(test_result)
+        render.extend(
+            [
+                htpy.h3[f"Module {m.module}"],
+                rt,
+                htpy.figure[
+                    htpy.img(src=f"{request.node.name}-{m.module}.png"),
+                    htpy.figcaption[f"ADC Frequency Sweep, Module {m.module}"],
+                ],
+            ]
+        )
+
+    with shelf as x:
+        x["sections"][request.node.name] = render
 
 
 @pytest.mark.asyncio
-async def test_dac_amplitude_transfer(d, results, summary_results, test_highbank, num_runs, results_dir):
-    '''
-    This test aims to determine if the output of the dac is scaled appropriately with the change in amplitude. The algorithm uses only 1 channel
-    at each module a set frequency, varying its amplitude. The result is compared to the transfer function prediction
-    
-    '''
+async def test_dac_amplitude_transfer(d, request, shelf, check):
+    """
+    ## DAC Amplitude Transfer Checks
+
+    This test aims to determine if the output of the dac is scaled
+    appropriately with the change in amplitude. The algorithm uses only 1
+    channel at each module a set frequency, varying its amplitude. The result
+    is compared to the transfer function prediction
+    """
+    render = [render_markdown(test_dac_amplitude_transfer.__doc__)]
+
     SCALE = 1
     SAMPLES = 100
     ATTENUATION = 0
@@ -419,234 +217,221 @@ async def test_dac_amplitude_transfer(d, results, summary_results, test_highbank
     NCO_FREQUENCY = 0
     FREQUENCY = 150.5763e6
     NOMINAL_AMPLITUDE = 0
-    TITLE = 'DAC Amplitude Transfer Test'
 
-    test_result = {
-        'title': TITLE,
-        'modules': []
-    }
-
-    highbank_run = False
-    #feel free to adjust the amplitude density as needed
+    # feel free to adjust the amplitude density as needed
     amplitudes = np.arange(0.05, 1, 0.05)
     d.clear_channels()
 
-    #num_runs passed from the config file depending on whether or not there will be a highbank run
-    for num_run in range(0, num_runs):
-        for module in range(1, 5):
-            module_errors = []
-            amplitude_values = []
-            magnitude_dbm_values = []
-            predicted_magnitude_dbm_values = []
+    for m in d.modules:
+        module_errors = []
+        amplitude_values = []
+        magnitude_dbm_values = []
+        predicted_magnitude_dbm_values = []
 
-            if highbank_run:
-                print(f'DAC_amplitude - Testing Module #:{module+4}')
-            else:
-                print(f'DAC_amplitude - Testing Module #:{module}')
-            
-            #When starting to test a new module, clear all channels and use the value_setter to set the variables that won't change attenuation, scale, frequency etc
-            value_setter_helper(d, FREQUENCY, NOMINAL_AMPLITUDE, SCALE, ATTENUATION, CHANNEL, module, NCO_FREQUENCY)
-            
+        # When starting to test a new module, clear all channels and use the value_setter to set the variables that won't change attenuation, scale, frequency etc
+        await value_setter_helper(
+            d,
+            FREQUENCY,
+            NOMINAL_AMPLITUDE,
+            SCALE,
+            ATTENUATION,
+            CHANNEL,
+            m.module,
+            NCO_FREQUENCY,
+        )
 
-            for amplitude in amplitudes:
-                d.set_amplitude(amplitude, d.UNITS.NORMALIZED, CHANNEL, module)
-                samples = await d.py_get_samples(SAMPLES, channel=CHANNEL, module=module)
-                median_magnitude_dbm, predicted_magnitude_dbm = transfer_function_helper(samples, amplitude, SCALE, ATTENUATION)
-                amplitude_values.append(amplitude)
-                magnitude_dbm_values.append(median_magnitude_dbm)
-                predicted_magnitude_dbm_values.append(predicted_magnitude_dbm)
+        for amplitude in amplitudes:
+            await d.set_amplitude(amplitude, d.UNITS.NORMALIZED, CHANNEL, m.module)
+            samples = await d.py_get_samples(SAMPLES, channel=CHANNEL, module=m.module)
+            median_magnitude_dbm, predicted_magnitude_dbm = transfer_function_helper(
+                samples, amplitude, SCALE, ATTENUATION
+            )
+            amplitude_values.append(amplitude)
+            magnitude_dbm_values.append(median_magnitude_dbm)
+            predicted_magnitude_dbm_values.append(predicted_magnitude_dbm)
 
-            errors = np.abs(np.array(magnitude_dbm_values) - np.array(predicted_magnitude_dbm_values))
-            if highbank_run:
-                module +=4
+        errors = np.abs(
+            np.array(magnitude_dbm_values) - np.array(predicted_magnitude_dbm_values)
+        )
 
-            #Linearity check on the scaling: apply linear regression and check least square error
-            log_amplitude_values = np.array(np.log10(amplitude_values)).reshape(-1, 1)
-            regressor = LinearRegression().fit(log_amplitude_values, magnitude_dbm_values)
-            linearity = r2_score(regressor.predict(log_amplitude_values), magnitude_dbm_values)
+        # Linearity check on the scaling: apply linear regression and check least square error
+        log_amplitude_values = np.array(np.log10(amplitude_values)).reshape(-1, 1)
+        regressor = LinearRegression().fit(log_amplitude_values, magnitude_dbm_values)
+        linearity = r2_score(
+            regressor.predict(log_amplitude_values), magnitude_dbm_values
+        )
 
+        # if any value is 3dB from predicted -- fail
+        if np.any(errors >= 3):
+            check.fail(f"Module {m.module}: power output deviated by > 3 dB")
 
-            #if any value is 3dB from predicted -- fail
-            if np.any(errors >= 3):
-                error = f'Generating a power output below 3dB of expected.'
-                print(f'Module {module} {error}')
-                module_errors.append(error)
+        if linearity < 0.999:
+            check.fail("The output is not linear on a lin-log scale.")
 
-            if linearity<0.999:
-                error = 'The output is not linear on a lin-log scale.'
-                print(error)
-                module_errors.append(error)
+        plt.figure(figsize=(10, 6))
+        plt.plot(
+            amplitude_values,
+            magnitude_dbm_values,
+            "-o",
+            label="measured",
+        )
+        plt.plot(
+            amplitude_values,
+            predicted_magnitude_dbm_values,
+            "-o",
+            label="predicted",
+        )
+        plt.xscale("log")
+        plt.xlabel("Amplitude (Normalized)")
+        plt.ylabel("Magnitude (dBm)")
+        plt.legend()
+        plt.title(f"DAC output of module {m.module} with increasing amplitude")
+        plt.grid(True)
+        plt.tight_layout()
+        plt.savefig(f"{request.session.results_dir}/{request.node.name}-{m.module}.png")
+        plt.close()
 
-            if not module_errors:
-                print(f"Module {module} passed DAC amplitude test.")
-            
-            module_result = {
-                'module': module,
-                'amplitude_values': amplitude_values,
-                'magnitude_dbm_values': magnitude_dbm_values,
-                'predicted_magnitude_dbm_values': predicted_magnitude_dbm_values,
-                'status': 'Fail' if module_errors else 'Pass',
-                'error': '\n'.join(module_errors),
-                'plot_path': 'plot_path'
-            }
+        render.extend(
+            [
+                htpy.h3[f"Module {m.module}"],
+                htpy.figure[
+                    htpy.img(src=f"{request.node.name}-{m.module}.png"),
+                    htpy.figcaption[f"DAC Amplitude Transfer Function, {m.module}"],
+                ],
+            ]
+        )
 
-            graph_name = TITLE + "_module_"+ f'{module_result["module"]}' +'.png'
-            plot_path = os.path.join(results_dir, 'plots', graph_name)
-            module_result["plot_path"] = plot_path  
-
-            plt.figure(figsize=(10, 6))
-            plt.plot(module_result['amplitude_values'], module_result['magnitude_dbm_values'], '-o', label = 'measured' )
-            plt.plot(module_result['amplitude_values'], module_result['predicted_magnitude_dbm_values'], '-o', label = 'predicted' )
-            plt.xscale('log')
-            plt.xlabel('Amplitude (Normalized)')
-            plt.ylabel('Magnitude (dBm)')
-            plt.legend()
-            plt.title(f'DAC output of module {module_result["module"]} with increasing amplitude')
-            plt.grid(True)
-            plt.tight_layout()
-            os.makedirs(os.path.dirname(plot_path), exist_ok=True)
-            plt.savefig(plot_path)
-            plt.close()
-
-            test_result['modules'].append(module_result)
-            if module not in summary_results['summary']:
-                summary_results['summary'][module] = {}
-            summary_results['summary'][module]['DAC Ampl'] = module_result['status']
-
-        if test_highbank:
-            d.set_analog_bank(True)
-            highbank_run = True
-        d.clear_channels()
-
-    d.set_analog_bank(False)
-    results['tests'].append(test_result)
+    with shelf as x:
+        x["sections"][request.node.name] = render
 
 
 @pytest.mark.asyncio
-async def test_dac_scale_transfer(d, results, summary_results, test_highbank, num_runs, results_dir):
-    '''
-    This test aims to determine if the output of the dac is scaled appropriately with the change in 'scale' value (actually controlled 
-    by varying the current in the balun). The algorithm uses only 1 channel at each module a set frequency, varying its scale. 
-    The result is compared to the transfer function prediction
+async def test_dac_scale_transfer(d, request, shelf, check):
+    """
+    ## DAC Scale Tests
+
+    This test aims to determine if the output of the dac is scaled
+    appropriately with the change in 'scale' value (actually controlled by
+    varying the current in the balun). The algorithm uses only 1 channel at
+    each module a set frequency, varying its scale.  The result is compared to
+    the transfer function prediction
 
     Potentially add:
-    Pick 4 channels, set the same frequency-> alter scale and plot the samples first, then convert to dBm
-    plot together with prediction from the transfer funciton
-    '''
-    #set parameters for testing
-    AMPLITUDE= 1
+    * Pick 4 channels, set the same frequency-> alter scale and plot the
+      samples first, then convert to dBm
+    * plot together with prediction from the transfer function
+    """
+    render = [render_markdown(test_dac_scale_transfer.__doc__)]
+
+    # set parameters for testing
+    AMPLITUDE = 1
     NOMINAL_SCALE = 1
     SAMPLES = 100
     FREQUENCY = 150.5763e6
     NCO_FREQUENCY = 0
     ATTENUATION = 0
     CHANNEL = 1
-    TITLE = 'DAC Scale Transfer Test'
-    #dictionary just for this test will be appended to all the results at the end (could modify to avoid losing data if a pytest crash occurs)
-    test_result = {
-        'title': TITLE,
-        'modules': []
-    }
-    for mod in range (1,4):
-        d.set_adc_calibration_mode('MODE1', mod)
+    TITLE = "DAC Scale Transfer Test"
+    # dictionary just for this test will be appended to all the results at the end (could modify to avoid losing data if a pytest crash occurs)
+    test_result = {"title": TITLE, "modules": []}
 
-    highbank_run = False
-    for num_run in range (0, num_runs):
-        for module in range (1,5):
-            # Initialize lists to store the scale and magnitude values
-            module_errors = []
-            scale_values = []
-            magnitude_dbm_values = []
-            predicted_magnitude_dbm_values = []
+    for m in d.modules:
+        await d.set_adc_calibration_mode("MODE1", m.module)
 
-            d.clear_channels()
-            value_setter_helper(d, FREQUENCY, AMPLITUDE, NOMINAL_SCALE, ATTENUATION, CHANNEL, module, NCO_FREQUENCY)
-            module_sample = module
+    for m in d.modules:
+        # Initialize lists to store the scale and magnitude values
+        scale_values = []
+        magnitude_dbm_values = []
+        predicted_magnitude_dbm_values = []
 
-            if highbank_run:
-                module_set= module +4
-            else:
-                module_set = module
-            
-            print(f'DAC_scale - Testing Module #: {module_set}')
+        await d.clear_channels()
+        await value_setter_helper(
+            d,
+            FREQUENCY,
+            AMPLITUDE,
+            NOMINAL_SCALE,
+            ATTENUATION,
+            CHANNEL,
+            m.module,
+            NCO_FREQUENCY,
+        )
 
-            for scale in range (0, 8):
-                
-                d.set_dac_scale(scale, d.UNITS.DBM, module_set)
-                raw_sampl = await d.py_get_samples(SAMPLES, channel=CHANNEL, module=module_sample)
-                median_magnitude_dbm, predicted_magnitude_dbm = transfer_function_helper(raw_sampl, AMPLITUDE, scale, ATTENUATION)
-                
-                scale_values.append(scale)
-                magnitude_dbm_values.append(median_magnitude_dbm)
-                predicted_magnitude_dbm_values.append(predicted_magnitude_dbm)
+        for scale in range(0, 8):
 
-            #Power check on the DAC
-            errors = np.abs(np.array(magnitude_dbm_values) - np.array(predicted_magnitude_dbm_values))
-            
-            if np.any(errors >= 3):
-                error = f'Module {module_set} is generating a power output below 3dB of expected'
-                print(error)
-                module_errors.append(error)
+            await d.set_dac_scale(scale, d.UNITS.DBM, m.module)
+            raw_sampl = await d.py_get_samples(
+                SAMPLES, channel=CHANNEL, module=m.module
+            )
+            median_magnitude_dbm, predicted_magnitude_dbm = transfer_function_helper(
+                raw_sampl, AMPLITUDE, scale, ATTENUATION
+            )
 
-            #Linearity check on the scaling: apply linear regression and check least square error
-            scale_values = np.array(scale_values).reshape(-1, 1)
-            regressor = LinearRegression().fit(scale_values, magnitude_dbm_values)
-            linearity = r2_score(regressor.predict(scale_values), magnitude_dbm_values)
-            if linearity<0.99:
-                error = 'linearity check failed'
-                module_errors.append(error)
-                print(error)
-            if not module_errors:
-                print(f'Module {module_set} passed the DAC scaling test')
-                    
-            module_result = {
-                'module': module_set,
-                'scale_values': scale_values.flatten().tolist(),
-                'magnitude_dbm_values': magnitude_dbm_values,
-                'predicted_magnitude_dbm_values': predicted_magnitude_dbm_values,
-                'status': 'Fail' if module_errors else 'Pass',
-                'errors': f'{module_errors}',
-                'plot_path': 'plot_path'
-            }
+            scale_values.append(scale)
+            magnitude_dbm_values.append(median_magnitude_dbm)
+            predicted_magnitude_dbm_values.append(predicted_magnitude_dbm)
 
-            #same as in above tests, the path to the plot will be used by the report_generator
-            graph_name = TITLE + "_module_"+ f'{module_result["module"]}' +'.png'
-            plot_path = os.path.join(results_dir, 'plots', graph_name)
-            module_result["plot_path"] = plot_path  
+        # Power check on the DAC
+        errors = np.abs(
+            np.array(magnitude_dbm_values) - np.array(predicted_magnitude_dbm_values)
+        )
 
-            plt.figure(figsize=(10, 6))
-            plt.plot(module_result['scale_values'], module_result['magnitude_dbm_values'], '-o', label = 'measured' )
-            plt.plot(module_result['scale_values'], module_result['predicted_magnitude_dbm_values'], '-o', label = 'predicted' )
-            plt.xlabel('Scale(dBm)')
-            plt.ylabel('Magnitude (dBm)')
-            plt.legend()
-            plt.title(f'DAC output of module {module_result["module"]} with increasing scale (dBm)')
-            plt.grid(True)
-            plt.tight_layout()
-            os.makedirs(os.path.dirname(plot_path), exist_ok=True)
-            plt.savefig(plot_path)
-            plt.close()
+        if np.any(errors >= 3):
+            check.fail(
+                f"Module {m.module} is generating a power output below 3dB of expected"
+            )
 
-            test_result['modules'].append(module_result)
-            if module_set not in summary_results['summary']:
-                summary_results['summary'][module_set] = {}
-            summary_results['summary'][module_set]['DAC Scale'] = module_result['status']
+        # Linearity check on the scaling: apply linear regression and check least square error
+        scale_values = np.array(scale_values).reshape(-1, 1)
+        regressor = LinearRegression().fit(scale_values, magnitude_dbm_values)
+        linearity = r2_score(regressor.predict(scale_values), magnitude_dbm_values)
+        if linearity < 0.99:
+            check.fail("linearity check failed")
 
-        if test_highbank:
-            d.set_analog_bank(True)
-            highbank_run = True
+        plt.figure(figsize=(10, 6))
+        plt.plot(
+            scale_values.flatten().tolist(),
+            magnitude_dbm_values,
+            "-o",
+            label="measured",
+        )
+        plt.plot(
+            scale_values.flatten().tolist(),
+            predicted_magnitude_dbm_values,
+            "-o",
+            label="predicted",
+        )
+        plt.xlabel("Scale(dBm)")
+        plt.ylabel("Magnitude (dBm)")
+        plt.legend()
+        plt.title(f"DAC output of module {m.module} with increasing scale (dBm)")
+        plt.grid(True)
+        plt.tight_layout()
+        plt.savefig(f"{request.session.results_dir}/{request.node.name}-{m.module}.png")
+        plt.close()
 
-    d.set_analog_bank(False)
-    results['tests'].append(test_result)
+        render.extend(
+            [
+                htpy.h3[f"Module {m.module}"],
+                htpy.figure[
+                    htpy.img(src=f"{request.node.name}-{m.module}.png"),
+                    htpy.figcaption[f"ADC Frequency Sweep, Module {m.module}"],
+                ],
+            ]
+        )
 
+    with shelf as x:
+        x["sections"][request.node.name] = render
+
+
+@pytest.mark.xfail
 @pytest.mark.asyncio
 async def test_dac_mixmodes(d, results, summary_results, test_highbank):
-    '''
+    """
     This test aims to verify the overall behaviour of the nyquist zones (1(NRZ) or 2(RC)) set in the firmware as well as a sanity check for the hardware response in
-    the higher nquist regions. 
-    The test uses 3 modules at a time, getting the behaviour of a singular nyquist region from a singular module. The report generator then will stitch the 
+    the higher nquist regions.
+    The test uses 3 modules at a time, getting the behaviour of a singular nyquist region from a singular module. The report generator then will stitch the
     data together into one graph per nyquist zone.
-    '''
+    """
 
     MAX_TOTAL_FREQUENCY = 2.5e9  # in Hz
     DAC_MAX_FREQUENCY = 275e6  # in Hz (max DAC frequency)
@@ -660,142 +445,174 @@ async def test_dac_mixmodes(d, results, summary_results, test_highbank):
     MODULE_NYQUIST_MAP = {1: 1, 2: 2, 3: 3}
     CHANNEL = 1
 
-    #obtained through a separate loopback measurement: transferfunction applied to a 1000-count get_samples call
+    # obtained through a separate loopback measurement: transferfunction applied to a 1000-count get_samples call
     reference_data = {
-            'mixmode_1': {
-                'mod_region_1': {
-                    'frequencies': [761.78e6, 1302.56e6, 1902.34e6],
-                    'magnitudes': [-3.42, -4.82, -6.7]
-                },
-                'mod_region_2': {
-                    'frequencies': [4338.22e6, 3697.44e6, 3097.66e6],
-                    'magnitudes': [-24.87, -19.00, -13.82]
-                },
-                'mod_region_3': {
-                    'frequencies': [5761.78e6, 6302.56e6, 6902.34e6],
-                    'magnitudes': [-31.89, -27.84, -27.87]
-                }
+        "mixmode_1": {
+            "mod_region_1": {
+                "frequencies": [761.78e6, 1302.56e6, 1902.34e6],
+                "magnitudes": [-3.42, -4.82, -6.7],
             },
-            'mixmode_2': {
-                'mod_region_1': {
-                    'frequencies': [761.78e6, 1302.56e6, 1902.34e6],
-                    'magnitudes': [-16.41, -12.24, -10.21]
-                },
-                'mod_region_2': {
-                    'frequencies': [4238.22e6, 3697.44e6, 3097.66e6],
-                    'magnitudes': [-12.30, -11.73,-10.01 ]
-                },
-                'mod_region_3': {
-                    'frequencies': [5761.78e6, 6302.56e6, 6902.34e6],
-                    'magnitudes': [-19.66, -20.60, -24.93]
-                }
-            }
-        }
+            "mod_region_2": {
+                "frequencies": [4338.22e6, 3697.44e6, 3097.66e6],
+                "magnitudes": [-24.87, -19.00, -13.82],
+            },
+            "mod_region_3": {
+                "frequencies": [5761.78e6, 6302.56e6, 6902.34e6],
+                "magnitudes": [-31.89, -27.84, -27.87],
+            },
+        },
+        "mixmode_2": {
+            "mod_region_1": {
+                "frequencies": [761.78e6, 1302.56e6, 1902.34e6],
+                "magnitudes": [-16.41, -12.24, -10.21],
+            },
+            "mod_region_2": {
+                "frequencies": [4238.22e6, 3697.44e6, 3097.66e6],
+                "magnitudes": [-12.30, -11.73, -10.01],
+            },
+            "mod_region_3": {
+                "frequencies": [5761.78e6, 6302.56e6, 6902.34e6],
+                "magnitudes": [-19.66, -20.60, -24.93],
+            },
+        },
+    }
 
     async def mixmode_test_for_bank(bank_name, is_highbank):
         test_result = {
-            'title': f'DAC Mixmodes Test - {bank_name} bank',
-            'analog_bank': bank_name,
-            'mixmodes': []
+            "title": f"DAC Mixmodes Test - {bank_name} bank",
+            "analog_bank": bank_name,
+            "mixmodes": [],
         }
 
-        d.set_analog_bank(is_highbank)
+        await d.set_analog_bank(is_highbank)
 
         for mixmode in range(1, 3):
             for module, nyquist_zone in MODULE_NYQUIST_MAP.items():
                 module_setter = module
                 if is_highbank:
-                    module+=4
+                    module += 4
 
                 module_errors = []
                 module_magnitude_dbm_values = np.array([])
                 frequencies = np.array([])
-                print(f'Running module {module} in mixmode #{mixmode} nyquist region #{nyquist_zone} for {bank_name} bank')
+                print(
+                    f"Running module {module} in mixmode #{mixmode} nyquist region #{nyquist_zone} for {bank_name} bank"
+                )
 
-                d.set_nyquist_zone(mixmode, module=module)
+                await d.set_nyquist_zone(mixmode, module=module)
                 nco = 0
                 frequency = -DAC_MAX_FREQUENCY
 
                 while nco < MAX_TOTAL_FREQUENCY:
-                    while frequency <= DAC_MAX_FREQUENCY and nco + frequency < MAX_TOTAL_FREQUENCY:
+                    while (
+                        frequency <= DAC_MAX_FREQUENCY
+                        and nco + frequency < MAX_TOTAL_FREQUENCY
+                    ):
                         if nco + frequency >= 0:
-                            value_setter_helper(d, frequency, AMPLITUDE, SCALE, ATTENUATION, CHANNEL, module_setter, nco)
-                            samples = await d.py_get_samples(SAMPLES, channel=CHANNEL, module=module_setter)
-                            module_magnitude_dbm, _ = transfer_function_helper(samples, AMPLITUDE, SCALE, ATTENUATION)
+                            await value_setter_helper(
+                                d,
+                                frequency,
+                                AMPLITUDE,
+                                SCALE,
+                                ATTENUATION,
+                                CHANNEL,
+                                module_setter,
+                                nco,
+                            )
+                            samples = await d.py_get_samples(
+                                SAMPLES, channel=CHANNEL, module=module_setter
+                            )
+                            module_magnitude_dbm, _ = transfer_function_helper(
+                                samples, AMPLITUDE, SCALE, ATTENUATION
+                            )
 
                             if nyquist_zone == 1:
                                 frequencies = np.append(frequencies, frequency + nco)
-                                module_magnitude_dbm_values = np.append(module_magnitude_dbm_values, module_magnitude_dbm)
+                                module_magnitude_dbm_values = np.append(
+                                    module_magnitude_dbm_values, module_magnitude_dbm
+                                )
                             elif nyquist_zone == 2:
-                                frequencies = np.append(frequencies, 2 * SAMPLING_FREQUENCY - (frequency + nco))
-                                module_magnitude_dbm_values = np.append(module_magnitude_dbm_values, module_magnitude_dbm)
+                                frequencies = np.append(
+                                    frequencies,
+                                    2 * SAMPLING_FREQUENCY - (frequency + nco),
+                                )
+                                module_magnitude_dbm_values = np.append(
+                                    module_magnitude_dbm_values, module_magnitude_dbm
+                                )
                             elif nyquist_zone == 3:
-                                frequencies = np.append(frequencies, 2 * SAMPLING_FREQUENCY + frequency + nco)
-                                module_magnitude_dbm_values = np.append(module_magnitude_dbm_values, module_magnitude_dbm)
+                                frequencies = np.append(
+                                    frequencies,
+                                    2 * SAMPLING_FREQUENCY + frequency + nco,
+                                )
+                                module_magnitude_dbm_values = np.append(
+                                    module_magnitude_dbm_values, module_magnitude_dbm
+                                )
                         frequency += STEP
                     nco += BANDWIDTH
                     frequency = -DAC_MAX_FREQUENCY
 
-                reference_freqs = np.array(reference_data[f'mixmode_{mixmode}'][f'mod_region_{nyquist_zone}']['frequencies'])
-                reference_mags = np.array(reference_data[f'mixmode_{mixmode}'][f'mod_region_{nyquist_zone}']['magnitudes'])
+                reference_freqs = np.array(
+                    reference_data[f"mixmode_{mixmode}"][f"mod_region_{nyquist_zone}"][
+                        "frequencies"
+                    ]
+                )
+                reference_mags = np.array(
+                    reference_data[f"mixmode_{mixmode}"][f"mod_region_{nyquist_zone}"][
+                        "magnitudes"
+                    ]
+                )
 
-                for reference_freq, reference_mag in zip(reference_freqs, reference_mags):
+                for reference_freq, reference_mag in zip(
+                    reference_freqs, reference_mags
+                ):
                     if len(frequencies) == 0:
-                        module_errors.append(f"No frequencies measured for module {module} in Nyquist region {nyquist_zone}")
+                        check.fail(
+                            f"No frequencies measured for module {module} in Nyquist region {nyquist_zone}"
+                        )
                         continue
 
                     closest_index = np.argmin(np.abs(frequencies - reference_freq))
                     obtained_magnitude = module_magnitude_dbm_values[closest_index]
 
-                    if not (0.8 * abs(reference_mag) <= abs(obtained_magnitude) <= 1.15 * abs(reference_mag)):
-                        module_errors.append(f"Frequency {frequencies[closest_index] / 1e6:.2f} MHz: measured {obtained_magnitude:.2f} dBm, expected {reference_freq/1e6:.2f} to have {reference_mag} dBm")
-                
-                if module_errors:
-                    print(module_errors)
-                else:
-                    print('Module outputs within 15 percent of expected value')
+                    if not (
+                        0.8 * abs(reference_mag)
+                        <= abs(obtained_magnitude)
+                        <= 1.15 * abs(reference_mag)
+                    ):
+                        check.fail(
+                            f"Frequency {frequencies[closest_index] / 1e6:.2f} MHz: measured {obtained_magnitude:.2f} dBm, expected {reference_freq/1e6:.2f} to have {reference_mag} dBm"
+                        )
 
-                status = 'Fail' if module_errors else 'Pass'
-                test_result['mixmodes'].append({
-                    'mixmode': mixmode,
-                    'module': module,
-                    'frequencies': frequencies.tolist(),
-                    'magnitude_dbm_values': module_magnitude_dbm_values.tolist(),
-                    'reference_frequencies': reference_freqs.tolist(),
-                    'reference_magnitudes': reference_mags.tolist(), 
-                    'status': status
-                })
-                if module not in summary_results['summary']:
-                    summary_results['summary'][module] = {}
-                summary_results['summary'][module][f'Mixmode {mixmode}'] = status
+                test_result["mixmodes"].append(
+                    {
+                        "mixmode": mixmode,
+                        "module": module,
+                        "frequencies": frequencies.tolist(),
+                        "magnitude_dbm_values": module_magnitude_dbm_values.tolist(),
+                        "reference_frequencies": reference_freqs.tolist(),
+                        "reference_magnitudes": reference_mags.tolist(),
+                    }
+                )
+                if module not in summary_results["summary"]:
+                    summary_results["summary"][module] = {}
                 if mixmode == 2:
-                    d.set_nyquist_zone(1, module=module)
+                    await d.set_nyquist_zone(1, module=module)
 
-        results['tests'].append(test_result)
+        results["tests"].append(test_result)
 
     # Run test for low bank
-    await mixmode_test_for_bank('low', False)
-
-    # If high bank needs to be tested, prompt the user to switch filters and run again
-    if test_highbank:
-        wait_for_action("Please switch filters from low to high banks before proceeding with high bank testing. \n \
-                        1st Nyquist filter to ADC#5,\n\
-                        2nd Nyquist filter to ADC#6,\n\
-                        3rd Nyquist filter to ADC#7\n \
-                        If already have filters connected - disregard this message")
-        
-        await mixmode_test_for_bank('high', True)
-
-    d.set_analog_bank(False)
+    await mixmode_test_for_bank("low", False)
 
 
+"""---------------------------------------------------------------------------------------------------------------"""
+"""--------------------------------------------------ADC----------------------------------------------------------"""
 
 
-'''---------------------------------------------------------------------------------------------------------------'''
-'''--------------------------------------------------ADC----------------------------------------------------------'''
-
+@pytest.mark.xfail
 @pytest.mark.asyncio
-async def test_adc_attenuation(d, results, summary_results, test_highbank, num_runs, results_dir):
+async def test_adc_attenuation(
+    d, results, summary_results, test_highbank, num_runs, results_dir
+):
     AMPLITUDE = 1
     SAMPLES = 100
     FREQUENCY = 80.234562e6
@@ -803,97 +620,109 @@ async def test_adc_attenuation(d, results, summary_results, test_highbank, num_r
     SCALE = 1
     CHANNEL = 1
     ATTENUATION_0 = 0
-    TITLE = 'ADC Attenuation Test'
+    TITLE = "ADC Attenuation Test"
 
-    test_result = {
-        'title': TITLE,
-        'modules': []
-    }
+    test_result = {"title": TITLE, "modules": []}
 
-    highbank_run = False
-    for num_run in range (0, num_runs):
-        for module in range(1, 5):
+    for num_run in range(0, num_runs):
+        for m in d.modules:
             module_errors = []
             attenuation_values = []
             magnitude_dbm_values = []
             predicted_magnitude_dbm_values = []
 
             d.clear_channels()
-            value_setter_helper(d, FREQUENCY, AMPLITUDE, SCALE, ATTENUATION_0, CHANNEL, module, NCO_FREQUENCY)
+            await value_setter_helper(
+                d,
+                FREQUENCY,
+                AMPLITUDE,
+                SCALE,
+                ATTENUATION_0,
+                CHANNEL,
+                m.module,
+                NCO_FREQUENCY,
+            )
 
-            module_sample = module
-            if highbank_run:
-                module_set= module +4
-            else:
-                module_set = module
-            
-            print(f'ADC_attenuation - Testing Module #: {module_set}')
+            print(f"ADC_attenuation - Testing Module #{m.module}")
 
             for attenuation in range(0, 15):
-                d.set_adc_attenuator(attenuation, d.UNITS.DB, module=module_set)
-                raw_sampl = await d.py_get_samples(SAMPLES, channel=CHANNEL, module=module_sample)
-                median_magnitude_dbm, predicted_magnitude_dbm = transfer_function_helper(raw_sampl, AMPLITUDE, SCALE, attenuation)
+                await d.set_adc_attenuator(attenuation, d.UNITS.DB, module=m.module)
+                raw_sampl = await d.py_get_samples(
+                    SAMPLES, channel=CHANNEL, module=m.module
+                )
+                median_magnitude_dbm, predicted_magnitude_dbm = (
+                    transfer_function_helper(raw_sampl, AMPLITUDE, SCALE, attenuation)
+                )
                 attenuation_values.append(attenuation)
                 magnitude_dbm_values.append(median_magnitude_dbm)
                 predicted_magnitude_dbm_values.append(predicted_magnitude_dbm)
 
             attenuation_values = np.array(attenuation_values).reshape(-1, 1)
             regressor = LinearRegression().fit(attenuation_values, magnitude_dbm_values)
-            linearity = r2_score(magnitude_dbm_values, regressor.predict(attenuation_values))
+            linearity = r2_score(
+                magnitude_dbm_values, regressor.predict(attenuation_values)
+            )
 
             if linearity < 0.99:
-                error = f'linearity check failed'
-                print(error)
-                module_errors.append(error)
+                check.fail(f"linearity check failed")
 
-            if np.any(np.abs(np.array(magnitude_dbm_values) - np.array(predicted_magnitude_dbm_values)) >= 1):
-                error = f'Module {module_set} is generating a power output lower than expected. Check your balun and SMA connections.'
-                module_errors.append(error)
-                print(error)
+            if np.any(
+                np.abs(
+                    np.array(magnitude_dbm_values)
+                    - np.array(predicted_magnitude_dbm_values)
+                )
+                >= 1
+            ):
+                check.fail(
+                    f"Module {m.module} is generating a power output lower than expected. Check your balun and SMA connections."
+                )
 
-            else:
-                print(f"Module {module_set} passed ADC attenuation tests.")
             module_result = {
-                'module': module_set,
-                'attenuation_values': attenuation_values.flatten().tolist(),
-                'magnitude_dbm_values': magnitude_dbm_values,
-                'predicted_magnitude_dbm_values': predicted_magnitude_dbm_values,
-                'status': 'Fail' if module_errors else 'Pass',
-                'errors': f'{module_errors}',
-                'plot_path': 'plot_path'
+                "module": m.module,
+                "attenuation_values": attenuation_values.flatten().tolist(),
+                "magnitude_dbm_values": magnitude_dbm_values,
+                "predicted_magnitude_dbm_values": predicted_magnitude_dbm_values,
+                "plot_path": "plot_path",
             }
 
-            graph_name = TITLE + "_module_"+ f'{module_result["module"]}' +'.png'
-            plot_path = os.path.join(results_dir, 'plots', graph_name)
-            module_result["plot_path"] = plot_path  
+            graph_name = TITLE + "_module_" + f"{module_result[m.module]}" + ".png"
+            plot_path = os.path.join(results_dir, "plots", graph_name)
+            module_result["plot_path"] = plot_path
 
             plt.figure(figsize=(10, 6))
-            plt.plot(module_result['attenuation_values'], module_result['magnitude_dbm_values'], '-o', label = 'measured' )
-            plt.plot(module_result['attenuation_values'], module_result['predicted_magnitude_dbm_values'], '-o', label = 'predicted' )
-            plt.xlabel('Attenuation(dBm)')
-            plt.ylabel('Magnitude (dBm)')
+            plt.plot(
+                module_result["attenuation_values"],
+                module_result["magnitude_dbm_values"],
+                "-o",
+                label="measured",
+            )
+            plt.plot(
+                module_result["attenuation_values"],
+                module_result["predicted_magnitude_dbm_values"],
+                "-o",
+                label="predicted",
+            )
+            plt.xlabel("Attenuation(dBm)")
+            plt.ylabel("Magnitude (dBm)")
             plt.legend()
-            plt.title(f'Signal at ADC of module {module_result["module"]} with increasing attenuation')
+            plt.title(
+                f'Signal at ADC of module {module_result["module"]} with increasing attenuation'
+            )
             plt.grid(True)
             plt.tight_layout()
             os.makedirs(os.path.dirname(plot_path), exist_ok=True)
             plt.savefig(plot_path)
             plt.close()
 
+            test_result["modules"].append(module_result)
 
-            test_result['modules'].append(module_result)
+            if module_set not in summary_results["summary"]:
+                summary_results["summary"][module_set] = {}
+            summary_results["summary"][module_set][f"ADC Atten"] = module_result[
+                "status"
+            ]
 
-            if module_set not in summary_results['summary']:
-                summary_results['summary'][module_set] = {}
-            summary_results['summary'][module_set][f'ADC Atten'] = module_result['status']   
-
-        if test_highbank:
-            d.set_analog_bank(True)
-            highbank_run = True
-
-    d.set_analog_bank(False)
-    results['tests'].append(test_result)
-
+    results["tests"].append(test_result)
 
 
 @pytest.mark.skip(reason="no way of currently testing this")
@@ -906,332 +735,91 @@ async def test_adc_even_phase(d, results):
     SCALE = 1
     CHANNEL = 1
     module = 1
-    test_result = {
-        'title': 'ADC Even Phase Test',
-        'modules': []
-    }
+    test_result = {"title": "ADC Even Phase Test", "modules": []}
     for module in range(1, 5):
-        value_setter_helper(d, FREQUENCY, AMPLITUDE, SCALE, 0, CHANNEL, module, NCO_FREQUENCY)
+        await value_setter_helper(
+            d, FREQUENCY, AMPLITUDE, SCALE, 0, CHANNEL, module, NCO_FREQUENCY
+        )
         x = await d.py_get_samples(SAMPLES, channel=1, module=1)
-    
+
         data_i_samples = np.array(x.i)
         data_q_samples = np.array(x.q)
         data_samples = np.column_stack((data_i_samples, data_q_samples))
         ratio = covariance_matrix(data_samples)
         print(f"Eigenvalue ratio: {ratio}")
         module_result = {
-            'module': module,
-            'module': module,
-            'data_i_samples': data_i_samples.tolist(),
-            'data_q_samples': data_q_samples.tolist(),
-            'ratio': ratio
+            "module": module,
+            "module": module,
+            "data_i_samples": data_i_samples.tolist(),
+            "data_q_samples": data_q_samples.tolist(),
+            "ratio": ratio,
         }
-        test_result['modules'].append(module_result)
-    
-    results['tests'].append(test_result)
-    
+        test_result["modules"].append(module_result)
+
+    results["tests"].append(test_result)
+
     if np.isclose(ratio, 1, atol=0.1):
         print("The cluster is approximately circular.")
     else:
         print("The cluster is more oval in shape.")
 
-#used in the test_loopback_noise
-def psd_helper(data_i_raw, data_q_raw):
-    COMB_SAMPLING_FREQUENCY = 625e6
-    volts_peak = (np.sqrt(2)) * np.sqrt(50 * (10 ** (-1.75 / 10)) / 1000) / 1880796.4604246316
-    # Convert I and Q to peak volts
-    tod_i = data_i_raw * volts_peak
-    tod_q = data_q_raw * volts_peak
-
-    # Define the sampling frequency for the ADC
-    fir = (COMB_SAMPLING_FREQUENCY / 256 / 64 / 2 ** 6)
-    # Apply Welch's method to get the signal PSD
-    psdfreq, psd_i = signal.welch(tod_i/np.sqrt(4*50), fir, nperseg=len(tod_i// 4)) #tod_i / np.sqrt(4 * 50) 
-    _, psd_q = signal.welch(tod_q/np.sqrt(4*50), fir, nperseg=len(tod_q// 4)) #tod_q / np.sqrt(4 * 50)
-
-    # Convert from watts to dBm
-    psd_i = 10 * np.log10(psd_i*1000)
-    psd_q = 10 * np.log10(psd_q*1000)
-    return psd_i, psd_q, psdfreq
-       
 
 @pytest.mark.asyncio
-async def test_loopback_noise(d, results, summary_results, test_highbank, num_runs, results_dir):
-    '''
-    1. Send a signal with no amplitude to gauge the noise floor, and any spikes in the noise floor
-    2. Send a higher power signal to dominate the output with 1/f noise. Determine the slope of 1/f and any unusual spikes
-    '''
-    SAMPLES = 10000
-
-    # Set parameters for testing white noise floor
-    AMPLITUDE_0 = 0
-    FREQUENCY = 277.234562e6
-    NCO_FREQUENCY = 0
-    SCALE = 1
-    ATTENUATION = 0
-    CHANNEL_WHITE = 1
-
-    # Set parameters for 1/f slope and peak noise
-    AMPLITUDE_1_F = 1
-    FREQUENCY_1_F = 277.987e6
-    NCO_FREQUENCY_1_F = 0
-    SCALE_1_F = 1
-    ATTENUATION_1_F = 0
-    CHANNEL_1_F = 784
-    EXPECTED_SLOPE = -1
-    TITLE = 'Loopback Noise Test'
-    test_result = {
-        'title': TITLE,
-        'modules': []
-    }
-    highbank_run = False
-    print(f'Just in case, i am not dead, just slow. At 10k samples -- 1 min/module. At 60k samples 4 min/module...')
-    for num_run in range (0, num_runs):
-        for mod in range(1,5):
-
-            if highbank_run:
-                print(f'Loopback Noise - Testing Module #:{mod+4}')
-            else:
-                print(f'Loopback Noise - Testing Module #:{mod}')
-
-            floor_errors = []
-            loud_errors = []
-
-            # 1. Test the noise environment: send a signal with no amplitude and plot the PSD of the samples
-            d.clear_channels()
-            value_setter_helper(d, FREQUENCY, AMPLITUDE_0, SCALE, ATTENUATION, CHANNEL_WHITE, mod, NCO_FREQUENCY)
-            raw_samples_white = await d.py_get_samples(SAMPLES, channel=CHANNEL_WHITE, module=mod)
-            data_i_white = np.array(raw_samples_white.i)
-            data_q_white = np.array(raw_samples_white.q)
-            psd_i_white, psd_q_white, psdfreq_white = psd_helper(data_i_white, data_q_white)
-
-
-            # 2. Test the PSD of a large signal, establishing an expectation for 1/f slope and peak noise at low frequency
-            value_setter_helper(d, FREQUENCY_1_F, AMPLITUDE_1_F, SCALE_1_F, ATTENUATION_1_F, CHANNEL_1_F, mod, NCO_FREQUENCY_1_F)
-            raw_samples_psd = await d.py_get_samples(SAMPLES, channel=CHANNEL_1_F, module=mod)
-            data_i_1_f = np.array(raw_samples_psd.i)
-            data_q_1_f = np.array(raw_samples_psd.q)
-            psd_i_1_f, psd_q_1_f, psdfreq_1_f = psd_helper(data_i_1_f, data_q_1_f)
-
-
-            # Compute the max points in the white noise and low frequency regions
-            max_point_white_i = np.max(psd_i_white)
-            max_point_white_q = np.max(psd_q_white)
-            max_point_1_f_i = np.max(psd_i_1_f)
-            max_point_1_f_q = np.max(psd_q_1_f)
-            mean_point_white_i = np.mean(psd_i_white)
-            mean_point_white_q = np.mean(psd_q_white)
-
-            if highbank_run:
-                mod +=4
-            
-            #check if any spikes are present
-            if 0.95*(-163.4) < mean_point_white_i or 0.95*(-163.4) < mean_point_white_q:
-                floor_errors.append('Noise floor of module {mod} is higher than expected')
-            if  max_point_1_f_i > -79 or max_point_1_f_q >-79:
-                loud_errors.append('Noise levels for frequencies dominated by 1/f are higher than -79dBm')
-            
-
-            # Filter the PSDs for plotting
-            mask_plot = (psdfreq_1_f > 0) & (psdfreq_1_f < 150)
-            psdfreq_1_f_plot = psdfreq_1_f[mask_plot]
-            psd_i_1_f_plot = psd_i_1_f[mask_plot]
-            psd_q_1_f_plot = psd_q_1_f[mask_plot]
-
-            # Filter the PSDs for fitting
-            mask_fit = (psdfreq_1_f > 0) & (psdfreq_1_f < 15)
-            psdfreq_1_f_fit = psdfreq_1_f[mask_fit]
-            psd_i_1_f_fit = psd_i_1_f[mask_fit] 
-            psd_q_1_f_fit = psd_q_1_f[mask_fit]
-
-            # Combine I and Q components for fitting
-            combined_psd_1_f_fit = np.concatenate((psd_i_1_f_fit, psd_q_1_f_fit))
-            combined_freqs_fit = np.concatenate((psdfreq_1_f_fit, psdfreq_1_f_fit))
-
-            # Combine I and Q components for plotting
-            combined_psd_1_f = np.concatenate((psd_i_1_f_plot, psd_q_1_f_plot))
-            combined_freqs = np.concatenate((psdfreq_1_f_plot, psdfreq_1_f_plot))
-            
-            # Convert PSD from dBm/Hz to W/Hz for fitting
-            psd_values_W_Hz_fit = 10 ** ((combined_psd_1_f_fit - 30) / 10)
-
-            # Perform a linear fit in the log-log space
-            log_frequencies_fit = np.log10(combined_freqs_fit)
-            log_psd_values_fit = np.log10(psd_values_W_Hz_fit)
-
-            # Linear regression to find the slope and intercept
-            slope, intercept, r_value, p_value, std_err = linregress(log_frequencies_fit, log_psd_values_fit)
-
-            # Calculate the fitted line in log space over the full range for plotting
-            log_frequencies_plot = np.log10(combined_freqs)
-            fitted_log_psd_values_plot = intercept + slope * log_frequencies_plot
-
-            # Convert fitted values back to linear scale for plotting
-            fitted_psd_values_W_Hz_plot = 10 ** fitted_log_psd_values_plot
-            fitted_psd_values_dBm_Hz_plot = 10 * np.log10(fitted_psd_values_W_Hz_plot) + 30
-
-            if slope < 1.1*EXPECTED_SLOPE or slope > 0.9*EXPECTED_SLOPE:
-                loud_errors.append('1/f noise deviates from the expected value of -1')
-        
-            module_result = {
-                'module': mod,
-                'psd_i_white': psd_i_white.tolist(),
-                'psd_q_white': psd_q_white.tolist(),
-                'psd_frequencies_white': psdfreq_white.tolist(),
-                'max_point_white_i': max_point_white_i.tolist(),
-                'max_point_white_q': max_point_white_q.tolist(),
-                'psd_i_1_f': psd_i_1_f.tolist(),
-                'psd_q_1_f': psd_q_1_f.tolist(),
-                'psd_frequencies_1_f': psdfreq_1_f.tolist(),
-                'combined_psd_1_f': combined_psd_1_f.tolist(),
-                'combined_freqs': combined_freqs.tolist(),  # This should be the original combined frequency list
-                'max_point_1_f_i': max_point_1_f_i.tolist(),
-                'max_point_1_f_q': max_point_1_f_q.tolist(),
-                'fitted_psd_values_dBm_Hz': fitted_psd_values_dBm_Hz_plot.tolist(),
-                'slope': slope,
-                'white_status': 'Fail' if floor_errors else 'Pass',
-                '1_f_status': 'Fail' if loud_errors else 'Pass',
-                'plot_path_white': 'plot_path_white',
-                'plot_path_1_f': 'plot_path_1_f'
-            }
-
-            graph_name_white = TITLE + "_white_"+"_module_"+ f'{module_result["module"]}' +'.png'
-            plot_path_white = os.path.join(results_dir, 'plots', graph_name_white)
-            module_result["plot_path_white"] = plot_path_white  
-
-            graph_name_1_f = TITLE +"_1_f" + "_module_"+ f'{module_result["module"]}' +'.png'
-            plot_path_1_f = os.path.join(results_dir, 'plots', graph_name_1_f)
-            module_result["plot_path_1_f"] = plot_path_1_f
-
-            #plot the white noise
-            plt.figure(figsize=(10, 6))
-            plt.plot(module_result['psd_frequencies_white'], module_result['psd_i_white'],  label = 'I' )
-            plt.plot(module_result['psd_frequencies_white'], module_result['psd_q_white'], label = 'Q' )
-            plt.scatter([module_result['psd_frequencies_white'][np.argmax(module_result['psd_i_white'])]], [module_result['max_point_white_i']], color='red', label=f'Max I spike: {module_result["max_point_white_i"]:.2f} dBm')
-            plt.scatter([module_result['psd_frequencies_white'][np.argmax(module_result['psd_q_white'])]], [module_result['max_point_white_q']], color='green', label=f'Max Q spike: {module_result["max_point_white_q"]:.2f} dBm')
-            plt.xlabel('Frequency (Hz from carrier)')
-            plt.ylabel('Magnitude (dBm)')
-            plt.xscale('log')
-            plt.legend()
-            plt.title(f'Noise floor in loopback at 277.23MHz at module {mod}')
-            plt.grid(True)
-            plt.tight_layout()
-            os.makedirs(os.path.dirname(plot_path_white), exist_ok=True)
-            plt.savefig(plot_path_white)
-            plt.close()
-
-             # 1/f noise PSD
-            plt.figure(figsize=(10, 6))
-            plt.plot(module_result['combined_freqs'], module_result['fitted_psd_values_dBm_Hz'], 'r', label=f'fit to 1/f spectrum: n = {module_result["slope"]:.2f}')
-            plt.scatter(module_result['combined_freqs'], module_result['combined_psd_1_f'], label='1/f spectrum data')
-            plt.scatter([module_result['psd_frequencies_1_f'][np.argmax(module_result['psd_i_1_f'])]], [module_result['max_point_1_f_i']], color='red', label=f'Max I spike: {module_result["max_point_1_f_i"]:.2f} dBm')
-            plt.scatter([module_result['psd_frequencies_1_f'][np.argmax(module_result['psd_q_1_f'])]], [module_result['max_point_1_f_q']], color='green', label=f'Max Q spike: {module_result["max_point_1_f_q"]:.2f} dBm')
-            plt.xscale('log')
-            plt.title('PSD of 1/f Noise')
-            plt.xlabel('Frequency (Hz)')
-            plt.ylabel('PSD (dBm/Hz)')
-            plt.legend()
-            plt.tight_layout()
-            os.makedirs(os.path.dirname(plot_path_1_f), exist_ok=True)
-            plt.savefig(plot_path_1_f)
-            plt.close()
-
-
-
-            if mod not in summary_results['summary']:
-                summary_results['summary'][mod] = {}
-            summary_results['summary'][mod]['Noise floor'] = module_result['white_status']
-            summary_results['summary'][mod]['1/f Noise'] = module_result['1_f_status']
-        
-            test_result['modules'].append(module_result)
-        
-        if test_highbank:
-            d.set_analog_bank(True)
-            highbank_run = True
-
-    d.set_analog_bank(False)
-    results['tests'].append(test_result)
-
-
-
-@pytest.mark.asyncio
-async def test_wideband_noise(d, results, summary_results, test_highbank, num_runs, results_dir):
+async def test_wideband_noise(d, request, shelf, check):
+    """
+    ## Wideband Noise Checks
+    """
+    render = [render_markdown(test_wideband_noise.__doc__)]
 
     SAMPLING_FREQUENCY = 5e9  # 5 GHz
     NUM_SAMPLES = 4000  # Total number of samples
-    highbank_run = False
-    TITLE =  'Wideband FFT for Noise Detection'
 
-    test_result = {
-        'title': TITLE,
-        'modules': []
-    }
+    for m in d.modules:
+        await d.clear_channels()
+        time.sleep(1)
+        samples = await d.get_fast_samples(NUM_SAMPLES, module=m.module)
 
-    for num_run in range(0, num_runs):
-        for mod in range(1, 5):
+        volts_peak_samples = (
+            (np.sqrt(2))
+            * np.sqrt(50 * (10 ** (-1.75 / 10)) / 1000)
+            / 1880796.4604246316
+        )
+        I_signal = np.array(samples.i) * volts_peak_samples
+        Q_signal = np.array(samples.q) * volts_peak_samples
 
-            if highbank_run:
-                print(f'Wideband FFT - Testing Module #:{mod + 4}')
-            else:
-                print(f'Wideband FFT - Testing Module #:{mod}')
+        psdfreq_i, psd_i = signal.welch(
+            I_signal / np.sqrt(4 * 50), SAMPLING_FREQUENCY, nperseg=NUM_SAMPLES
+        )  # tod_i / np.sqrt(4 * 50)
+        psdfreq_q, psd_q = signal.welch(
+            Q_signal / np.sqrt(4 * 50), SAMPLING_FREQUENCY, nperseg=NUM_SAMPLES
+        )  # tod_q / np.sqrt(4 * 50)
 
-            d.clear_channels()
-            time.sleep(1)
-            samples = await d.get_fast_samples(NUM_SAMPLES, module=mod)
+        # Convert from watts to dBm
+        psd_i = 10 * np.log10(psd_i * 1000)
+        psd_q = 10 * np.log10(psd_q * 1000)
 
-            volts_peak_samples = (np.sqrt(2)) * np.sqrt(50 * (10 ** (-1.75 / 10)) / 1000) / 1880796.4604246316
-            I_signal = np.array(samples.i) * volts_peak_samples
-            Q_signal = np.array(samples.q) * volts_peak_samples
+        # plot the white noise
+        plt.figure(figsize=(10, 6))
+        plt.plot(psdfreq_i.tolist(), psd_i.tolist(), label="I")
+        plt.plot(psdfreq_q.tolist(), psd_q.tolist(), label="Q")
+        plt.xlabel("Frequency (Hz)")
+        plt.ylabel("Magnitude (dBm/Hz)")
+        plt.legend()
+        plt.title(f"Wideband FFT at module {m.module}")
+        plt.grid(True)
+        plt.tight_layout()
+        plt.savefig(f"{request.session.results_dir}/{request.node.name}-{m.module}.png")
+        plt.close()
 
+        render.extend(
+            [
+                htpy.h3[f"Module {m.module}"],
+                htpy.figure[
+                    htpy.img(src=f"{request.node.name}-{m.module}.png"),
+                    htpy.figcaption[f"Wideband Noise, Module {m.module}"],
+                ],
+            ]
+        )
 
-            psdfreq_i, psd_i = signal.welch(I_signal/np.sqrt(4*50), SAMPLING_FREQUENCY, nperseg=NUM_SAMPLES) #tod_i / np.sqrt(4 * 50) 
-            psdfreq_q, psd_q = signal.welch(Q_signal/np.sqrt(4*50), SAMPLING_FREQUENCY, nperseg=NUM_SAMPLES) #tod_q / np.sqrt(4 * 50)
-
-            # Convert from watts to dBm
-            psd_i = 10 * np.log10(psd_i*1000)
-            psd_q = 10 * np.log10(psd_q*1000)
-
-            if highbank_run:
-                mod+=4
-
-            module_result = {
-                'module': mod,
-                'psd_i': psd_i.tolist(),
-                'psd_q': psd_q.tolist(),
-                'freqs_i': psdfreq_i.tolist(),
-                'freqs_q': psdfreq_q.tolist(),
-                'status': 'N/A',
-                'plot_path': 'plot_path'
-            }
-
-            if mod not in summary_results['summary']:
-                summary_results['summary'][mod] = {}
-            summary_results['summary'][mod]['Wide FFT'] = module_result['status']
-
-            graph_name = TITLE +"_module_"+ f'{module_result["module"]}' +'.png'
-            plot_path = os.path.join(results_dir, 'plots', graph_name)
-            module_result["plot_path"] = plot_path 
-
-            #plot the white noise
-            plt.figure(figsize=(10, 6))
-            plt.plot(module_result['freqs_i'], module_result['psd_i'],  label = 'I' )
-            plt.plot(module_result['freqs_q'], module_result['psd_q'], label = 'Q' )
-            plt.xlabel('Frequency (Hz)')
-            plt.ylabel('Magnitude (dBm/Hz)')
-            plt.legend()
-            plt.title(f'Wideband FFT at module {module_result["module"]}')
-            plt.grid(True)
-            plt.tight_layout()
-            os.makedirs(os.path.dirname(plot_path), exist_ok=True)
-            plt.savefig(plot_path)
-            plt.close()
-
-            test_result['modules'].append(module_result)
-
-        if test_highbank:
-            d.set_analog_bank(True)
-            highbank_run = True
-
-    d.set_analog_bank(False)
-    results['tests'].append(test_result)
-    
+    with shelf as x:
+        x["sections"][request.node.name] = render

--- a/test/crs_qc/test_crs_basics.py
+++ b/test/crs_qc/test_crs_basics.py
@@ -16,7 +16,9 @@ from .crs_qc import render_markdown, ResultTable
 @pytest.mark.qc_stage1
 @pytest.mark.asyncio
 async def test_communications(d, request, shelf, check):
-    """
+    report = [
+        render_markdown(
+            f"""
     ## Basic board communications tests
 
     Tests the following:
@@ -28,8 +30,10 @@ async def test_communications(d, request, shelf, check):
     If any of these tests fail, you should stop here and debug your test setup
     before proceeding with more complex tests.
     """
+        )
+    ]
 
-    rt = ResultTable("Check", "Status")
+    report.append(rt := ResultTable("Check", "Status"))
     hostname = f'rfmux{request.config.getoption("--serial")}.local'
 
     # 1. Can we resolve the board?
@@ -45,11 +49,10 @@ async def test_communications(d, request, shelf, check):
         # Coming up after this is a py_get_samples() call. Because
         # py_get_samples uses "module=1", we sneak in a set_analog_bank(False)
         # call here to ensure we aren't inadvertently set up for high banking.
-        text = requests.post(f"http://{hostname}/tuber", json={
-            "object":"Dfmux",
-            "method":"set_analog_bank",
-            "args":[False]
-        }).text
+        text = requests.post(
+            f"http://{hostname}/tuber",
+            json={"object": "Dfmux", "method": "set_analog_bank", "args": [False]},
+        ).text
         rt.pass_("HTTP POST", "Pass")
     except Exception as e:
         rt.fail("HTTP POST", e.message)
@@ -64,30 +67,28 @@ async def test_communications(d, request, shelf, check):
         check.fail(str(e))
 
     with shelf as x:
-        x["sections"][request.node.nodeid] = [
-            render_markdown(test_communications.__doc__),
-            rt,
-        ]
+        x["sections"][request.node.nodeid] = report
 
 
 @pytest.mark.qc_stage1
 @pytest.mark.asyncio
 async def test_metadata(d, request, shelf):
-    """
+    report = [
+        render_markdown(
+            f"""
     ## Metadata Retrieval
 
     The board includes helper functions to retrieve its own metadata. This
     function tests the structure of this metadata and also displays the results
     for record-keeping.
     """
+        )
+    ]
 
-    rt = ResultTable("Attribute", "Value")
+    report.append(rt := ResultTable("Attribute", "Value"))
     r = await d.get_firmware_release()
     for k in r:
         rt.row(k, getattr(r, k))
 
     with shelf as x:
-        x["sections"][request.node.nodeid] = [
-            render_markdown(test_metadata.__doc__),
-            rt,
-        ]
+        x["sections"][request.node.nodeid] = report

--- a/test/crs_qc/test_crs_basics.py
+++ b/test/crs_qc/test_crs_basics.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env -S pytest-3 -s
+"""
+Basic bring-up tests
+
+Please see README for hints on using and extending these test cases.
+"""
+
+import pytest
+import socket
+import requests
+
+from .crs_qc import render_markdown, ResultTable
+
+
+# Ensure network can resolve the board. Does not use rfmux.
+@pytest.mark.qc
+@pytest.mark.asyncio
+async def test_communications(d, request, shelf, check):
+    """
+    ## Basic board communications tests
+
+    Tests the following:
+
+    * Is the CRS board alive?
+    * Can we send commands to it?
+    * Can we retrieve multicast samples from it?
+
+    If any of these tests fail, you should stop here and debug your test setup
+    before proceeding with more complex tests.
+    """
+
+    rt = ResultTable("Check", "Status")
+    hostname = f'rfmux{request.config.getoption("--serial")}.local'
+
+    # 1. Can we resolve the board?
+    try:
+        address = socket.gethostbyname(hostname)
+        rt.pass_("Name resolution", "Pass")
+    except Exception as e:
+        rt.fail("Name resolution", e.message)
+        check.fail(e.message)
+
+    # 2. Can we make a bare/empty HTTP request to it?
+    try:
+        text = requests.post(f"http://{hostname}/tuber", data="[]").text
+        rt.pass_("HTTP POST", "Pass")
+    except Exception as e:
+        rt.fail("HTTP POST", e.message)
+        check.fail(e.message)
+
+    # 3. Can we receive multicast packets directly?
+    try:
+        x = await d.py_get_samples(1, module=1, channel=1)
+        rt.pass_("Multicast reception", "Pass")
+    except Exception as e:
+        rt.fail("Multicast reception", str(e))
+        check.fail(str(e))
+
+    shelf["sections"][request.node.name] = [
+        render_markdown(test_communications.__doc__),
+        rt,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_metadata(d, request, shelf):
+    """
+    ## Metadata Retrieval
+
+    The board includes helper functions to retrieve its own metadata. This
+    function tests the structure of this metadata and also displays the results
+    for record-keeping.
+    """
+
+    rt = ResultTable("Attribute", "Value")
+    r = await d.get_firmware_release()
+    for k in r:
+        rt.row(k, getattr(r, k))
+
+    shelf["sections"][request.node.name] = [
+        render_markdown(test_metadata.__doc__),
+        rt,
+    ]

--- a/test/crs_qc/test_crs_basics.py
+++ b/test/crs_qc/test_crs_basics.py
@@ -64,7 +64,7 @@ async def test_communications(d, request, shelf, check):
         check.fail(str(e))
 
     with shelf as x:
-        x["sections"][request.node.name] = [
+        x["sections"][request.node.nodeid] = [
             render_markdown(test_communications.__doc__),
             rt,
         ]
@@ -87,7 +87,7 @@ async def test_metadata(d, request, shelf):
         rt.row(k, getattr(r, k))
 
     with shelf as x:
-        x["sections"][request.node.name] = [
+        x["sections"][request.node.nodeid] = [
             render_markdown(test_metadata.__doc__),
             rt,
         ]

--- a/test/crs_qc/test_crs_basics.py
+++ b/test/crs_qc/test_crs_basics.py
@@ -41,8 +41,8 @@ async def test_communications(d, request, shelf, check):
         address = socket.gethostbyname(hostname)
         rt.pass_("Name resolution", "Pass")
     except Exception as e:
-        rt.fail("Name resolution", e.message)
-        check.fail(e.message)
+        rt.fail("Name resolution", str(e))
+        check.fail(str(e))
 
     # 2. Can we make a bare HTTP request to it?
     try:
@@ -55,8 +55,8 @@ async def test_communications(d, request, shelf, check):
         ).text
         rt.pass_("HTTP POST", "Pass")
     except Exception as e:
-        rt.fail("HTTP POST", e.message)
-        check.fail(e.message)
+        rt.fail("HTTP POST", str(e))
+        check.fail(str(e))
 
     # 3. Can we receive multicast packets directly?
     try:

--- a/test/crs_qc/test_crs_basics.py
+++ b/test/crs_qc/test_crs_basics.py
@@ -13,7 +13,7 @@ from .crs_qc import render_markdown, ResultTable
 
 
 # Ensure network can resolve the board. Does not use rfmux.
-@pytest.mark.qc
+@pytest.mark.qc_stage1
 @pytest.mark.asyncio
 async def test_communications(d, request, shelf, check):
     """
@@ -40,9 +40,16 @@ async def test_communications(d, request, shelf, check):
         rt.fail("Name resolution", e.message)
         check.fail(e.message)
 
-    # 2. Can we make a bare/empty HTTP request to it?
+    # 2. Can we make a bare HTTP request to it?
     try:
-        text = requests.post(f"http://{hostname}/tuber", data="[]").text
+        # Coming up after this is a py_get_samples() call. Because
+        # py_get_samples uses "module=1", we sneak in a set_analog_bank(False)
+        # call here to ensure we aren't inadvertently set up for high banking.
+        text = requests.post(f"http://{hostname}/tuber", json={
+            "object":"Dfmux",
+            "method":"set_analog_bank",
+            "args":[False]
+        }).text
         rt.pass_("HTTP POST", "Pass")
     except Exception as e:
         rt.fail("HTTP POST", e.message)
@@ -63,6 +70,7 @@ async def test_communications(d, request, shelf, check):
         ]
 
 
+@pytest.mark.qc_stage1
 @pytest.mark.asyncio
 async def test_metadata(d, request, shelf):
     """

--- a/test/crs_qc/test_crs_basics.py
+++ b/test/crs_qc/test_crs_basics.py
@@ -56,10 +56,11 @@ async def test_communications(d, request, shelf, check):
         rt.fail("Multicast reception", str(e))
         check.fail(str(e))
 
-    shelf["sections"][request.node.name] = [
-        render_markdown(test_communications.__doc__),
-        rt,
-    ]
+    with shelf as x:
+        x["sections"][request.node.name] = [
+            render_markdown(test_communications.__doc__),
+            rt,
+        ]
 
 
 @pytest.mark.asyncio
@@ -77,7 +78,8 @@ async def test_metadata(d, request, shelf):
     for k in r:
         rt.row(k, getattr(r, k))
 
-    shelf["sections"][request.node.name] = [
-        render_markdown(test_metadata.__doc__),
-        rt,
-    ]
+    with shelf as x:
+        x["sections"][request.node.name] = [
+            render_markdown(test_metadata.__doc__),
+            rt,
+        ]

--- a/test/crs_qc/test_crs_housekeeping.py
+++ b/test/crs_qc/test_crs_housekeeping.py
@@ -74,7 +74,7 @@ async def test_housekeeping_temperature(d, request, shelf, check):
             rt.fail(s.name, v, s.nom, s.min, s.max)
 
     with shelf as x:
-        x["sections"][request.node.name] = [
+        x["sections"][request.node.nodeid] = [
             render_markdown(test_housekeeping_temperature.__doc__),
             rt,
         ]
@@ -189,7 +189,7 @@ async def test_housekeeping_voltages(d, request, shelf, check):
             rt.fail(s.name, v, s.nom, s.min, s.max)
 
     with shelf as x:
-        x["sections"][request.node.name] = [
+        x["sections"][request.node.nodeid] = [
             render_markdown(test_housekeeping_voltages.__doc__),
             rt,
         ]
@@ -233,7 +233,7 @@ async def test_housekeeping_currents(d, request, shelf, check):
             rt.fail(s.name, v, s.min, s.max)
 
     with shelf as x:
-        x["sections"][request.node.name] = [
+        x["sections"][request.node.nodeid] = [
             render_markdown(test_housekeeping_currents.__doc__),
             rt,
         ]

--- a/test/crs_qc/test_crs_housekeeping.py
+++ b/test/crs_qc/test_crs_housekeeping.py
@@ -45,20 +45,29 @@ async def test_housekeeping_temperature(d, request, shelf, check):
         )
     ]
 
-    NOM = 50.0
-    MIN = 0.0
-    MAX = 70.0
+    NOM = 50
+    MIN = 0
+    MAX = 70
+    MAX_DIE = 80
 
     sensors = (
         SensorReading(d.TEMPERATURE_SENSOR.MB_R5V0, nom=NOM, min=MIN, max=MAX),
+        SensorReading(d.TEMPERATURE_SENSOR.MB_R5V0_DIE, nom=NOM, min=MIN, max=MAX_DIE),
         SensorReading(d.TEMPERATURE_SENSOR.MB_R3V3A, nom=NOM, min=MIN, max=MAX),
+        SensorReading(d.TEMPERATURE_SENSOR.MB_R3V3A_DIE, nom=NOM, min=MIN, max=MAX_DIE),
         SensorReading(d.TEMPERATURE_SENSOR.MB_R2V5, nom=NOM, min=MIN, max=MAX),
+        SensorReading(d.TEMPERATURE_SENSOR.MB_R2V5_DIE, nom=NOM, min=MIN, max=MAX_DIE),
         SensorReading(d.TEMPERATURE_SENSOR.MB_R1V8, nom=NOM, min=MIN, max=MAX),
+        SensorReading(d.TEMPERATURE_SENSOR.MB_R1V8_DIE, nom=NOM, min=MIN, max=MAX_DIE),
         SensorReading(d.TEMPERATURE_SENSOR.MB_R1V2A, nom=NOM, min=MIN, max=MAX),
+        SensorReading(d.TEMPERATURE_SENSOR.MB_R1V2A_DIE, nom=NOM, min=MIN, max=MAX_DIE),
         SensorReading(d.TEMPERATURE_SENSOR.MB_R1V4, nom=NOM, min=MIN, max=MAX),
+        SensorReading(d.TEMPERATURE_SENSOR.MB_R1V4_DIE, nom=NOM, min=MIN, max=MAX_DIE),
         SensorReading(d.TEMPERATURE_SENSOR.MB_R1V2B, nom=NOM, min=MIN, max=MAX),
-        SensorReading(d.TEMPERATURE_SENSOR.MB_R0V85A, nom=NOM, min=MIN, max=MAX),
-        SensorReading(d.TEMPERATURE_SENSOR.MB_R0V85B, nom=NOM, min=MIN, max=MAX),
+        SensorReading(d.TEMPERATURE_SENSOR.MB_R1V2B_DIE, nom=NOM, min=MIN, max=MAX_DIE),
+        SensorReading(d.TEMPERATURE_SENSOR.MB_R0V85, nom=NOM, min=MIN, max=MAX),
+        SensorReading(d.TEMPERATURE_SENSOR.MB_R0V85A_DIE, nom=NOM, min=MIN, max=MAX_DIE),
+        SensorReading(d.TEMPERATURE_SENSOR.MB_R0V85B_DIE, nom=NOM, min=MIN, max=MAX_DIE),
         SensorReading(d.TEMPERATURE_SENSOR.RFSOC_PL, nom=NOM, min=MIN, max=MAX),
         SensorReading(d.TEMPERATURE_SENSOR.RFSOC_PS, nom=NOM, min=MIN, max=MAX),
     )
@@ -173,7 +182,7 @@ async def test_housekeeping_voltages(d, request, shelf, check):
         SensorReading.relative(d.VOLTAGE_SENSOR.RFSOC_VCCPSIO2, nom=3.3, rel=0.05),
         SensorReading.relative(d.VOLTAGE_SENSOR.RFSOC_VCCPSIO3, nom=3.3, rel=0.05),
         SensorReading(d.VOLTAGE_SENSOR.RFSOC_VCCVREFN, nom=0.0, min=-0.1, max=0.1),
-        SensorReading.relative(d.VOLTAGE_SENSOR.RFSOC_VCCVREFP, nom=1.85, rel=0.05),
+        SensorReading.relative(d.VOLTAGE_SENSOR.RFSOC_VCCVREFP, nom=1.25, rel=0.05),
         SensorReading(d.VOLTAGE_SENSOR.RFSOC_VCC_PSBATT, nom=0.0, min=-0.1, max=0.1),
         SensorReading(
             d.VOLTAGE_SENSOR.RFSOC_VCC_PSDDRPLL, nom=1.8, min=1.710, max=1.890

--- a/test/crs_qc/test_crs_housekeeping.py
+++ b/test/crs_qc/test_crs_housekeeping.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env -S uv run pytest -s
+"""
+Housekeeping Tests.
+
+Please see README for hints on using and extending these test cases.
+"""
+
+import pytest
+from dataclasses import dataclass
+
+from .crs_qc import render_markdown, ResultTable
+
+
+@dataclass
+class SensorReading:
+    name: str
+    nom: float
+    min: float
+    max: float
+
+    @classmethod
+    def relative(cls, name: str, nom: float, rel: float):
+        return cls(name, nom=nom, min=(1 - rel) * nom, max=(1 + rel) * nom)
+
+
+@pytest.mark.asyncio
+async def test_housekeeping_temperature(d, request, shelf, check):
+    """
+    ## Temperatures
+
+    Nominal values are fairly arbitrary. Selected maximum operating
+    temperatures taken from component datasheets are as follows:
+
+    * RFSoC: 100C
+    * PLLs: 85C (HMC7044, AD9574)
+    * VCXO: 70C (CVHD-950, standard option)
+    * Buck converters: 125C (LTM4638, LTM4636-1)
+
+    Given the board's thermal design and hot spots, it is likely that the VCXO
+    is the part with the lowest thermal margin.
+    """
+
+    NOM = 50.0
+    MIN = 0.0
+    MAX = 70.0
+
+    sensors = (
+        SensorReading(d.TEMPERATURE_SENSOR.MB_R5V0, nom=NOM, min=MIN, max=MAX),
+        SensorReading(d.TEMPERATURE_SENSOR.MB_R3V3A, nom=NOM, min=MIN, max=MAX),
+        SensorReading(d.TEMPERATURE_SENSOR.MB_R2V5, nom=NOM, min=MIN, max=MAX),
+        SensorReading(d.TEMPERATURE_SENSOR.MB_R1V8, nom=NOM, min=MIN, max=MAX),
+        SensorReading(d.TEMPERATURE_SENSOR.MB_R1V2A, nom=NOM, min=MIN, max=MAX),
+        SensorReading(d.TEMPERATURE_SENSOR.MB_R1V4, nom=NOM, min=MIN, max=MAX),
+        SensorReading(d.TEMPERATURE_SENSOR.MB_R1V2B, nom=NOM, min=MIN, max=MAX),
+        SensorReading(d.TEMPERATURE_SENSOR.MB_R0V85A, nom=NOM, min=MIN, max=MAX),
+        SensorReading(d.TEMPERATURE_SENSOR.MB_R0V85B, nom=NOM, min=MIN, max=MAX),
+        SensorReading(d.TEMPERATURE_SENSOR.RFSOC_PL, nom=NOM, min=MIN, max=MAX),
+        SensorReading(d.TEMPERATURE_SENSOR.RFSOC_PS, nom=NOM, min=MIN, max=MAX),
+    )
+
+    async with d.tuber_context() as ctx:
+        for s in sensors:
+            ctx.get_motherboard_temperature(s.name)
+        temps = await ctx()
+
+    rt = ResultTable(
+        "Sensor", r"Reading (C)", "Nominal (C)", "Minimum (C)", r"Maximum (C)"
+    )
+    for s, v in zip(sensors, temps):
+        if check(s.min <= v <= s.max):
+            rt.pass_(s.name, v, s.nom, s.min, s.max)
+        else:
+            rt.fail(s.name, v, s.nom, s.min, s.max)
+
+    with shelf as x:
+        x["sections"][request.node.name] = [
+            render_markdown(test_housekeeping_temperature.__doc__),
+            rt,
+        ]
+
+
+@pytest.mark.asyncio
+async def test_housekeeping_voltages(d, request, shelf, check):
+    """
+    ## Voltages
+
+    There are, in general, two kinds of on-board voltage measurements:
+
+    * Point-of-supply (POS) measurements, provided by I2C peripherals that are
+      physically close to the regulators. Since we typically use remote-sense
+      configurations for regulators, voltages measured here are higher than the
+      set-point where PDN resistance causes a voltage drop.
+    * Point-of-load (POL) measurements, provided inside or near a load IC.
+
+    Maximum and minimum values for these rails are set as follows:
+
+    * Point-of-supply (POS) measurements are allowed a relatively loose (10%)
+      regulation tolerance, on the assumption that remote sense and POL
+      measurements give us better constraints
+    * Point-of-load (POL) measurements take their min/max values verbatim from
+      the relevant component datasheets (primarily, DS926).
+    """
+
+    VOLTAGE_TOL = 0.10  # 10%
+    sensors = (
+        # The VBP rail is primarily limited by a "hard max" for the LTM4638
+        # buck converter of 16V. This part's recommendex maximum is 15V.
+        #
+        # For rev4 and newer CRSes:
+        # - VBP is measured at -ve node of F1
+        # - voltage at LTM4638 is reduced by PDN and IR drop across L1
+        # - over/undervoltage protection provided by U8
+        #
+        # For rev3 and older CRSes:
+        # - VBP is measured at +ve node of F1
+        # - voltage at LTM4638 is reduced by PDN and IR drop across F1 and Q13
+        # - no overvoltage protection
+        # - undervoltage protection (of a kind) provided by Q2/D3 - but this
+        #   seems to make the system repeatedly cycle through its reset state
+        SensorReading(d.VOLTAGE_SENSOR.MB_VBP, nom=12.0, min=8.0, max=16.0),
+        # These rails are measured at the power supply, which is in turn
+        # remotely sensed at point of load - so a sloppy margin here is OK,
+        # provided we have tighter margins at the POL.
+        SensorReading.relative(d.VOLTAGE_SENSOR.MB_R0V85A, nom=0.85, rel=0.1),
+        SensorReading.relative(d.VOLTAGE_SENSOR.MB_R0V85B, nom=0.85, rel=0.1),
+        SensorReading.relative(d.VOLTAGE_SENSOR.MB_R1V2A, nom=1.2, rel=0.1),
+        SensorReading.relative(d.VOLTAGE_SENSOR.MB_R1V2B, nom=1.2, rel=0.1),
+        SensorReading.relative(d.VOLTAGE_SENSOR.MB_R1V4, nom=1.4, rel=0.1),
+        SensorReading.relative(d.VOLTAGE_SENSOR.MB_R1V8A, nom=1.8, rel=0.1),
+        SensorReading.relative(d.VOLTAGE_SENSOR.MB_R2V5, nom=2.5, rel=0.1),
+        SensorReading.relative(d.VOLTAGE_SENSOR.MB_R3V3A, nom=3.3, rel=0.1),
+        SensorReading.relative(d.VOLTAGE_SENSOR.MB_R5V0, nom=5.0, rel=0.1),
+        # These rails are measured at the RFSoC, and stricter margins are good
+        # practice. These numbers typically come from DS926 Table 2.
+        SensorReading(
+            d.VOLTAGE_SENSOR.RFSOC_PSMGTRAVCC, nom=0.85, min=0.825, max=0.875
+        ),
+        SensorReading(d.VOLTAGE_SENSOR.RFSOC_PSMGTRAVTT, nom=1.8, min=1.746, max=1.854),
+        # VCCAMS is an internal name referring to VCCADC @ 1.8v, not VCCINT_AMS @ 0.85 v
+        SensorReading(d.VOLTAGE_SENSOR.RFSOC_VCCAMS, nom=1.8, min=1.710, max=1.890),
+        SensorReading(d.VOLTAGE_SENSOR.RFSOC_VCCAUX, nom=1.8, min=1.710, max=1.890),
+        SensorReading(d.VOLTAGE_SENSOR.RFSOC_VCCBRAM, nom=0.85, min=0.825, max=0.876),
+        SensorReading(d.VOLTAGE_SENSOR.RFSOC_VCCINT, nom=0.85, min=0.825, max=0.876),
+        SensorReading(d.VOLTAGE_SENSOR.RFSOC_VCCPLAUX, nom=1.8, min=1.746, max=1.854),
+        SensorReading(
+            d.VOLTAGE_SENSOR.RFSOC_VCCPLINTFP, nom=0.85, min=0.825, max=0.876
+        ),
+        SensorReading(
+            d.VOLTAGE_SENSOR.RFSOC_VCCPLINTLP, nom=0.85, min=0.825, max=0.876
+        ),
+        SensorReading(d.VOLTAGE_SENSOR.RFSOC_VCCPSAUX, nom=1.8, min=1.710, max=1.890),
+        SensorReading.relative(d.VOLTAGE_SENSOR.RFSOC_VCCPSDDR, nom=1.2, rel=0.05),
+        SensorReading(
+            d.VOLTAGE_SENSOR.RFSOC_VCCPSINTFP, nom=0.85, min=0.808, max=0.892
+        ),
+        SensorReading(
+            d.VOLTAGE_SENSOR.RFSOC_VCCPSINTFPDDR, nom=0.85, min=0.808, max=0.892
+        ),
+        SensorReading(
+            d.VOLTAGE_SENSOR.RFSOC_VCCPSINTLP, nom=0.85, min=0.808, max=0.892
+        ),
+        SensorReading.relative(d.VOLTAGE_SENSOR.RFSOC_VCCPSIO0, nom=1.8, rel=0.05),
+        SensorReading.relative(d.VOLTAGE_SENSOR.RFSOC_VCCPSIO1, nom=3.3, rel=0.05),
+        SensorReading.relative(d.VOLTAGE_SENSOR.RFSOC_VCCPSIO2, nom=3.3, rel=0.05),
+        SensorReading.relative(d.VOLTAGE_SENSOR.RFSOC_VCCPSIO3, nom=3.3, rel=0.05),
+        SensorReading(d.VOLTAGE_SENSOR.RFSOC_VCCVREFN, nom=0.0, min=-0.1, max=0.1),
+        SensorReading.relative(d.VOLTAGE_SENSOR.RFSOC_VCCVREFP, nom=1.85, rel=0.05),
+        SensorReading(d.VOLTAGE_SENSOR.RFSOC_VCC_PSBATT, nom=0.0, min=-0.1, max=0.1),
+        SensorReading(
+            d.VOLTAGE_SENSOR.RFSOC_VCC_PSDDRPLL, nom=1.8, min=1.710, max=1.890
+        ),
+        SensorReading(d.VOLTAGE_SENSOR.RFSOC_VCC_PSPLL0, nom=1.2, min=1.164, max=1.236),
+    )
+
+    # Retrieve sensor values
+    async with d.tuber_context() as ctx:
+        for s in sensors:
+            ctx.get_motherboard_voltage(s.name)
+        voltages = await ctx()
+
+    # Evaluate pass/fail
+    rt = ResultTable("Sensor", "Reading", "Nominal", "Minimum", "Maximum")
+    for s, v in zip(sensors, voltages):
+        if check(s.min < v < s.max):
+            rt.pass_(s.name, v, s.nom, s.min, s.max)
+        else:
+            rt.fail(s.name, v, s.nom, s.min, s.max)
+
+    with shelf as x:
+        x["sections"][request.node.name] = [
+            render_markdown(test_housekeeping_voltages.__doc__),
+            rt,
+        ]
+
+
+@pytest.mark.asyncio
+async def test_housekeeping_currents(d, request, shelf, check):
+    """
+    ## Currents
+
+    Because current measurements rely on parasitic elements, these tests are
+    barely constrained and are mostly useful to gather historical measurements
+    of nominal values.
+    """
+
+    # These are sloppy measurements - give them a huge margin.
+    # Nominal readings aren't reported and are arbitrary.
+    sensors = (
+        SensorReading(d.CURRENT_SENSOR.MB_R0V85A, nom=1.0, min=0.1, max=10.0),
+        SensorReading(d.CURRENT_SENSOR.MB_R0V85B, nom=1.0, min=0.1, max=10.0),
+        SensorReading(d.CURRENT_SENSOR.MB_R1V2A, nom=1.0, min=0.1, max=10.0),
+        SensorReading(d.CURRENT_SENSOR.MB_R1V2B, nom=1.0, min=0.1, max=10.0),
+        SensorReading(d.CURRENT_SENSOR.MB_R1V4, nom=1.0, min=0.1, max=10.0),
+        SensorReading(d.CURRENT_SENSOR.MB_R1V8A, nom=1.0, min=0.1, max=10.0),
+        SensorReading(d.CURRENT_SENSOR.MB_R2V5, nom=1.0, min=0.1, max=10.0),
+        SensorReading(d.CURRENT_SENSOR.MB_R3V3A, nom=1.0, min=0.1, max=10.0),
+        SensorReading(d.CURRENT_SENSOR.MB_R5V0, nom=1.0, min=0.1, max=10.0),
+        SensorReading(d.CURRENT_SENSOR.MB_VBP, nom=1.0, min=0.1, max=10.0),
+    )
+    async with d.tuber_context() as ctx:
+        for s in sensors:
+            ctx.get_motherboard_current(s.name)
+        currents = await ctx()
+
+    rt = ResultTable("Sensor", "Reading (A)", "Minimum (A)", "Maximum (A)")
+    for s, v in zip(sensors, currents):
+        if check.between(v, s.min, s.max):
+            rt.pass_(s.name, v, s.min, s.max)
+        else:
+            rt.fail(s.name, v, s.min, s.max)
+
+    with shelf as x:
+        x["sections"][request.node.name] = [
+            render_markdown(test_housekeeping_currents.__doc__),
+            rt,
+        ]

--- a/test/crs_qc/test_crs_housekeeping.py
+++ b/test/crs_qc/test_crs_housekeeping.py
@@ -23,6 +23,7 @@ class SensorReading:
         return cls(name, nom=nom, min=(1 - rel) * nom, max=(1 + rel) * nom)
 
 
+@pytest.mark.qc_stage1
 @pytest.mark.asyncio
 async def test_housekeeping_temperature(d, request, shelf, check):
     """
@@ -79,6 +80,7 @@ async def test_housekeeping_temperature(d, request, shelf, check):
         ]
 
 
+@pytest.mark.qc_stage1
 @pytest.mark.asyncio
 async def test_housekeeping_voltages(d, request, shelf, check):
     """
@@ -193,6 +195,7 @@ async def test_housekeeping_voltages(d, request, shelf, check):
         ]
 
 
+@pytest.mark.qc_stage1
 @pytest.mark.asyncio
 async def test_housekeeping_currents(d, request, shelf, check):
     """

--- a/test/crs_qc/test_crs_housekeeping.py
+++ b/test/crs_qc/test_crs_housekeeping.py
@@ -83,7 +83,7 @@ async def test_housekeeping_temperature(d, request, shelf, check):
         )
     )
     for s, v in zip(sensors, temps):
-        if check(s.min <= v <= s.max):
+        if check.between(v, s.min, s.max):
             rt.pass_(s.name, v, s.nom, s.min, s.max)
         else:
             rt.fail(s.name, v, s.nom, s.min, s.max)
@@ -201,7 +201,7 @@ async def test_housekeeping_voltages(d, request, shelf, check):
         rt := ResultTable("Sensor", "Reading", "Nominal", "Minimum", "Maximum")
     )
     for s, v in zip(sensors, voltages):
-        if check(s.min < v < s.max):
+        if check.between(v, s.min, s.max):
             rt.pass_(s.name, v, s.nom, s.min, s.max)
         else:
             rt.fail(s.name, v, s.nom, s.min, s.max)

--- a/test/crs_qc/test_crs_loopback.py
+++ b/test/crs_qc/test_crs_loopback.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env -S pytest-3 -s
+"""
+Datapath tests
+
+Please see README for hints on using and extending these test cases.
+"""
+
+import htpy
+import os
+import pytest
+import rfmux
+import time
+import numpy as np
+import matplotlib.pyplot as plt
+
+from .crs_qc import render_markdown, ResultTable
+from scipy import signal
+from scipy.stats import linregress
+
+
+# used in the test_loopback_noise
+def psd_helper(data_i_raw, data_q_raw):
+    COMB_SAMPLING_FREQUENCY = 625e6
+    volts_peak = (
+        (np.sqrt(2)) * np.sqrt(50 * (10 ** (-1.75 / 10)) / 1000) / 1880796.4604246316
+    )
+    # Convert I and Q to peak volts
+    tod_i = data_i_raw * volts_peak
+    tod_q = data_q_raw * volts_peak
+
+    # Define the sampling frequency for the ADC
+    fir = COMB_SAMPLING_FREQUENCY / 256 / 64 / 2**6
+    # Apply Welch's method to get the signal PSD
+    psdfreq, psd_i = signal.welch(
+        tod_i / np.sqrt(4 * 50), fir, nperseg=len(tod_i // 4)
+    )  # tod_i / np.sqrt(4 * 50)
+    _, psd_q = signal.welch(
+        tod_q / np.sqrt(4 * 50), fir, nperseg=len(tod_q // 4)
+    )  # tod_q / np.sqrt(4 * 50)
+
+    # Convert from watts to dBm
+    psd_i = 10 * np.log10(psd_i * 1000)
+    psd_q = 10 * np.log10(psd_q * 1000)
+    return psd_i, psd_q, psdfreq
+
+
+@pytest.mark.asyncio
+async def test_loopback_noise(d, request, shelf, check):
+    """
+    ## Network Analysis - Ambient Noise
+
+    Using `take_specanal`, perform a wideband network analysis with no bias
+    tones.  This is a test of the noise environment.
+    """
+
+    # Documentation contained in the DocString
+    render = render_markdown(test_loopback_noise.__doc__)
+
+    FMAX = 2500e6  # Nyquist
+    MASK_FMIN = 50e6
+    MASK_FMAX = 2450e6
+    MASK_AMP = 1e1
+
+    # Plot setup
+    cycler = plt.rcParams["axes.prop_cycle"]
+    plt.figure(figsize=(10, 6))
+
+    rt = ResultTable("Module", "Mask Exceeded", "Max Masked Amplitude")
+
+    for m, color in zip(d.modules, cycler.by_key()["color"]):
+        await d.clear_channels()
+        await d.set_nco_frequency(0, module=m.module)
+        (fs, mags) = await d.take_specanal(
+            nsamps=100, fmin=0, fmax=FMAX, module=m.module, scaling="ps"
+        )
+
+        # Convert V^2/Hz to dBm
+        mags = 10 * np.log10(np.abs(mags)) + 30
+
+        # Plot magnitude
+        plt.semilogy(fs, np.abs(mags), "-,", color=color, label=f"Module {m.module}")
+
+        # Check if we exceeded the mask anywhere
+        errors = (np.abs(mags) > MASK_AMP) * (fs > MASK_FMIN) * (fs < MASK_FMAX)
+        plt.semilogy(
+            fs[errors], np.abs(mags[errors]), "o", color=color, fillstyle="none"
+        )
+
+        # Find and mark maxima within mask
+        fs_masked = fs[(fs > MASK_FMIN) * (fs < MASK_FMAX)]
+        mags_masked = mags[(fs > MASK_FMIN) * (fs < MASK_FMAX)]
+        nmax = np.argmax(np.abs(mags_masked))
+        fmax = fs_masked[nmax]
+        amax = np.abs(mags_masked[nmax])
+        plt.semilogy(fs_masked[nmax], amax, "o", color=color)
+
+        if any(errors):
+            check.fail(f"Mask check failed for module {m.module}")
+            rt.fail(
+                f"{m.module}",
+                f"{100.*sum(errors)/len(errors):.1f} %",
+                f"{amax:.1f} @ {fmax/1e6:.3f} MHz",
+            )
+        else:
+            rt.pass_(
+                f"{m.module}",
+                f"{100.*sum(errors)/len(errors):.1f} %",
+                f"{amax:.1f} @ {fmax/1e6:.3f} MHz",
+            )
+
+    # Draw the mask we're checking against
+    plt.plot(
+        [MASK_FMIN, MASK_FMIN, MASK_FMAX, MASK_FMAX],
+        [10 * MASK_AMP, MASK_AMP, MASK_AMP, 10 * MASK_AMP],
+        "k:",
+        label="Mask",
+    )
+
+    plt.xlabel("Frequency (MHz)")
+    plt.ylabel("Magnitude (V^2/Hz)")
+    plt.legend()
+    plt.grid(True)
+    plt.tight_layout()
+    plt.savefig(f"{request.session.results_dir}/{request.node.name}.png")
+    plt.close()
+
+    with shelf as x:
+        x["sections"][request.node.name] = [
+            render,
+            rt,
+            htpy.figure[
+                htpy.img(src=f"{request.node.name}.png"),
+                htpy.figcaption[f"Noise environment"],
+            ],
+        ]
+
+
+"""
+        # 2. Test the PSD of a large signal, establishing an expectation for 1/f slope and peak noise at low frequency
+        value_setter_helper(
+            d,
+            FREQUENCY_1_F,
+            AMPLITUDE_1_F,
+            SCALE_1_F,
+            ATTENUATION_1_F,
+            CHANNEL_1_F,
+            mod,
+            NCO_FREQUENCY_1_F,
+        )
+        raw_samples_psd = await d.py_get_samples(
+            SAMPLES, channel=CHANNEL_1_F, module=mod
+        )
+        data_i_1_f = np.array(raw_samples_psd.i)
+        data_q_1_f = np.array(raw_samples_psd.q)
+        psd_i_1_f, psd_q_1_f, psdfreq_1_f = psd_helper(data_i_1_f, data_q_1_f)
+
+        # Compute the max points in the white noise and low frequency regions
+        max_point_white_i = np.max(psd_i_white)
+        max_point_white_q = np.max(psd_q_white)
+        max_point_1_f_i = np.max(psd_i_1_f)
+        max_point_1_f_q = np.max(psd_q_1_f)
+        mean_point_white_i = np.mean(psd_i_white)
+        mean_point_white_q = np.mean(psd_q_white)
+
+        # check if any spikes are present
+        if (
+            0.95 * (-163.4) < mean_point_white_i
+            or 0.95 * (-163.4) < mean_point_white_q
+        ):
+            floor_errors.append(
+                "Noise floor of module {mod} is higher than expected"
+            )
+        if max_point_1_f_i > -79 or max_point_1_f_q > -79:
+            loud_errors.append(
+                "Noise levels for frequencies dominated by 1/f are higher than -79dBm"
+            )
+
+        # Filter the PSDs for plotting
+        mask_plot = (psdfreq_1_f > 0) & (psdfreq_1_f < 150)
+        psdfreq_1_f_plot = psdfreq_1_f[mask_plot]
+        psd_i_1_f_plot = psd_i_1_f[mask_plot]
+        psd_q_1_f_plot = psd_q_1_f[mask_plot]
+
+        # Filter the PSDs for fitting
+        mask_fit = (psdfreq_1_f > 0) & (psdfreq_1_f < 15)
+        psdfreq_1_f_fit = psdfreq_1_f[mask_fit]
+        psd_i_1_f_fit = psd_i_1_f[mask_fit]
+        psd_q_1_f_fit = psd_q_1_f[mask_fit]
+
+        # Combine I and Q components for fitting
+        combined_psd_1_f_fit = np.concatenate((psd_i_1_f_fit, psd_q_1_f_fit))
+        combined_freqs_fit = np.concatenate((psdfreq_1_f_fit, psdfreq_1_f_fit))
+
+        # Combine I and Q components for plotting
+        combined_psd_1_f = np.concatenate((psd_i_1_f_plot, psd_q_1_f_plot))
+        combined_freqs = np.concatenate((psdfreq_1_f_plot, psdfreq_1_f_plot))
+
+        # Convert PSD from dBm/Hz to W/Hz for fitting
+        psd_values_W_Hz_fit = 10 ** ((combined_psd_1_f_fit - 30) / 10)
+
+        # Perform a linear fit in the log-log space
+        log_frequencies_fit = np.log10(combined_freqs_fit)
+        log_psd_values_fit = np.log10(psd_values_W_Hz_fit)
+
+        # Linear regression to find the slope and intercept
+        slope, intercept, r_value, p_value, std_err = linregress(
+            log_frequencies_fit, log_psd_values_fit
+        )
+
+        # Calculate the fitted line in log space over the full range for plotting
+        log_frequencies_plot = np.log10(combined_freqs)
+        fitted_log_psd_values_plot = intercept + slope * log_frequencies_plot
+
+        # Convert fitted values back to linear scale for plotting
+        fitted_psd_values_W_Hz_plot = 10**fitted_log_psd_values_plot
+        fitted_psd_values_dBm_Hz_plot = (
+            10 * np.log10(fitted_psd_values_W_Hz_plot) + 30
+        )
+
+        if slope < 1.1 * EXPECTED_SLOPE or slope > 0.9 * EXPECTED_SLOPE:
+            loud_errors.append("1/f noise deviates from the expected value of -1")
+
+        module_result = {
+            "module": mod,
+            "psd_i_white": psd_i_white.tolist(),
+            "psd_q_white": psd_q_white.tolist(),
+            "psd_frequencies_white": psdfreq_white.tolist(),
+            "max_point_white_i": max_point_white_i.tolist(),
+            "max_point_white_q": max_point_white_q.tolist(),
+            "psd_i_1_f": psd_i_1_f.tolist(),
+            "psd_q_1_f": psd_q_1_f.tolist(),
+            "psd_frequencies_1_f": psdfreq_1_f.tolist(),
+            "combined_psd_1_f": combined_psd_1_f.tolist(),
+            "combined_freqs": combined_freqs.tolist(),  # This should be the original combined frequency list
+            "max_point_1_f_i": max_point_1_f_i.tolist(),
+            "max_point_1_f_q": max_point_1_f_q.tolist(),
+            "fitted_psd_values_dBm_Hz": fitted_psd_values_dBm_Hz_plot.tolist(),
+            "slope": slope,
+            "white_status": "Fail" if floor_errors else "Pass",
+            "1_f_status": "Fail" if loud_errors else "Pass",
+            "plot_path_white": "plot_path_white",
+            "plot_path_1_f": "plot_path_1_f",
+        }
+
+        graph_name_white = (
+            TITLE + "_white_" + "_module_" + f'{module_result["module"]}' + ".png"
+        )
+        plot_path_white = os.path.join(results_dir, "plots", graph_name_white)
+        module_result["plot_path_white"] = plot_path_white
+
+        graph_name_1_f = (
+            TITLE + "_1_f" + "_module_" + f'{module_result["module"]}' + ".png"
+        )
+        plot_path_1_f = os.path.join(results_dir, "plots", graph_name_1_f)
+        module_result["plot_path_1_f"] = plot_path_1_f
+
+        # plot the white noise
+        plt.figure(figsize=(10, 6))
+        plt.plot(
+            module_result["psd_frequencies_white"],
+            module_result["psd_i_white"],
+            label="I",
+        )
+        plt.plot(
+            module_result["psd_frequencies_white"],
+            module_result["psd_q_white"],
+            label="Q",
+        )
+        plt.scatter(
+            [
+                module_result["psd_frequencies_white"][
+                    np.argmax(module_result["psd_i_white"])
+                ]
+            ],
+            [module_result["max_point_white_i"]],
+            color="red",
+            label=f'Max I spike: {module_result["max_point_white_i"]:.2f} dBm',
+        )
+        plt.scatter(
+            [
+                module_result["psd_frequencies_white"][
+                    np.argmax(module_result["psd_q_white"])
+                ]
+            ],
+            [module_result["max_point_white_q"]],
+            color="green",
+            label=f'Max Q spike: {module_result["max_point_white_q"]:.2f} dBm',
+        )
+        plt.xlabel("Frequency (Hz from carrier)")
+        plt.ylabel("Magnitude (dBm)")
+        plt.xscale("log")
+        plt.legend()
+        plt.title(f"Noise floor in loopback at 277.23MHz at module {mod}")
+        plt.grid(True)
+        plt.tight_layout()
+        os.makedirs(os.path.dirname(plot_path_white), exist_ok=True)
+        plt.savefig(plot_path_white)
+        plt.close()
+
+        # 1/f noise PSD
+        plt.figure(figsize=(10, 6))
+        plt.plot(
+            module_result["combined_freqs"],
+            module_result["fitted_psd_values_dBm_Hz"],
+            "r",
+            label=f'fit to 1/f spectrum: n = {module_result["slope"]:.2f}',
+        )
+        plt.scatter(
+            module_result["combined_freqs"],
+            module_result["combined_psd_1_f"],
+            label="1/f spectrum data",
+        )
+        plt.scatter(
+            [
+                module_result["psd_frequencies_1_f"][
+                    np.argmax(module_result["psd_i_1_f"])
+                ]
+            ],
+            [module_result["max_point_1_f_i"]],
+            color="red",
+            label=f'Max I spike: {module_result["max_point_1_f_i"]:.2f} dBm',
+        )
+        plt.scatter(
+            [
+                module_result["psd_frequencies_1_f"][
+                    np.argmax(module_result["psd_q_1_f"])
+                ]
+            ],
+            [module_result["max_point_1_f_q"]],
+            color="green",
+            label=f'Max Q spike: {module_result["max_point_1_f_q"]:.2f} dBm',
+        )
+        plt.xscale("log")
+        plt.title("PSD of 1/f Noise")
+        plt.xlabel("Frequency (Hz)")
+        plt.ylabel("PSD (dBm/Hz)")
+        plt.legend()
+        plt.tight_layout()
+        os.makedirs(os.path.dirname(plot_path_1_f), exist_ok=True)
+        plt.savefig(plot_path_1_f)
+        plt.close()
+
+        if mod not in summary_results["summary"]:
+            summary_results["summary"][mod] = {}
+        summary_results["summary"][mod]["Noise floor"] = module_result[
+            "white_status"
+        ]
+        summary_results["summary"][mod]["1/f Noise"] = module_result["1_f_status"]
+
+        test_result["modules"].append(module_result)
+
+    if m.module >= 5:
+        d.set_analog_bank(high=True)
+
+    d.set_analog_bank(high=False)
+
+    with shelf as x:
+        x["sections"][request.node.name] = [
+                render,
+        ]
+        """

--- a/test/notebooks/.gitignore
+++ b/test/notebooks/.gitignore
@@ -1,0 +1,2 @@
+*.ipynb
+.ipynb_*

--- a/test/notebooks/test_notebooks.py
+++ b/test/notebooks/test_notebooks.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env -S JUPYTER_PLATFORM_DIRS=1 pytest-3 -s -v
+"""
+Notebook-Based Tests
+====================
+
+These tests execute in Jupyter Notebooks, which is a better environment than
+pytest for quantitative tests where visualizations are helpful.
+
+How this works
+--------------
+
+Tests are invoked using pytest as you'd expect:
+
+$ ./test_notebooks.py
+
+The 'test_jupyter_notebook' test case is parameterized, and causes any
+JupyterLab notebooks in the directory to be executed. One pytest test is
+executed per notebook. If all cells in a given notebooks run successfully, the
+test is considered as a "pass". Any exceptions raised in any notebook cells
+caues the associated test to fail.
+
+Viewing Test Rsults
+-------------------
+
+Files matching the pattern test_jupyter_notebook*.ipynb directory are test
+results, and can be viewed like any other .ipynb file. (Modifications to these
+files are not saved - you can edit and run them as normal, but should expect
+them to be overwritten.
+
+Modifying Tests
+---------------
+
+Test notebooks are stored as .md files and converted into .ipynb files
+automatically using jupytext. They can be converted to .ipynb files as follows:
+
+$ jupytext -o filename.ipynb filename.md
+
+You can then start a JupyterLab instance and mofiy the .ipynb file. This file
+must be re-converted to Markdown in order to be used as a test case. Only .md
+versions of jupyterlab notebooks should be stored in version control.
+
+You can convert a notebook stored in .md format to .ipynb as follows:
+
+$ jupytext -o filename.ipynb filename.md
+
+...and you can convert an .ipynb file back to its .md representation as
+follows:
+
+$ jupytext -o filename.md filename.ipynb
+"""
+
+import pytest
+import jupytext
+import nbformat
+import nbclient
+import glob
+
+
+@pytest.mark.parametrize("notebook_file", glob.glob("test*.md"))
+def test_jupytext_notebook(request, notebook_file):
+    with open(notebook_file, "r", encoding="utf-8") as f:
+        notebook = jupytext.read(f)
+
+    client = nbclient.NotebookClient(notebook, timeout=600, kernel_name="python3")
+
+    # Run the notebook and store the results in an .ipynb file, regardless of
+    # success/failure.
+    try:
+        client.execute()
+    except Exception as e:
+        raise AssertionError(
+            f"Notebook execution failed! Check {request.node.name}.ipynb for details."
+        ) from e
+    finally:
+        with open(f"{request.node.name}.ipynb", "w", encoding="utf-8") as f:
+            nbformat.write(notebook, f)

--- a/test/notebooks/test_py_get_samples.md
+++ b/test/notebooks/test_py_get_samples.md
@@ -1,0 +1,143 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.16.4
+  kernelspec:
+    display_name: Python 3 (ipykernel)
+    language: python
+    name: python3
+---
+
+# test_py_get_samples
+
+These tests demonstrate (and validate) scaling and conversion expectations for py_get_samples. They are kept here as a notebook in order to make the computations and results easier to visualize and explain.
+
+```python
+import sys
+sys.path.append('../../')
+import rfmux
+
+# We're going to need _compute_spectrum
+from rfmux.algorithms.measurement.py_get_samples \
+    import _compute_spectrum
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+```
+
+## DC signal in I only
+
+```python
+x = _compute_spectrum(np.ones(1000),
+                      np.zeros(1000),
+                      625e6 / (256 * 64 * 2**6), 6,
+                      scaling='ps')
+
+(freq_dsb, psd_dsb, psd_i, psd_q, freq_iq) = (
+    x["freq_dsb"],
+    x["psd_dual_sideband"],
+    x["psd_i"],
+    x["psd_q"],
+    x["freq_iq"],
+)
+
+plt.figure()
+plt.plot(np.fft.fftshift(freq_dsb),
+         np.fft.fftshift(psd_dsb), label="DSB")
+plt.plot(freq_iq, psd_i, label="I")
+plt.plot(freq_iq, psd_q, label="Q") # probably doesn't show
+plt.xlabel('Frequency (Hz)')
+plt.ylabel('Amp (dBc)')
+plt.legend()
+plt.grid(True)
+plt.tight_layout()
+
+# Q had better be negligible
+assert all(psd_q < -300)
+
+# I and DSB spectra are only allowed energy at DC
+assert all((psd_i < -300) | (np.abs(freq_iq) < 1))
+assert all((psd_dsb < -300) | (np.abs(freq_dsb) < 1))
+
+# magnitude 1 -> expect 0 dB
+assert max(psd_i) == pytest.approx(0, abs=1)
+assert max(psd_dsb) == pytest.approx(0, abs=1)
+```
+
+## DC signal in Q only
+
+```python
+x = _compute_spectrum(np.zeros(1000),
+                      np.ones(1000),
+                      625e6 / (256 * 64 * 2**6), 6,
+                      scaling='ps')
+
+(freq_dsb, psd_dsb, psd_i, psd_q, freq_iq) = (
+    x["freq_dsb"],
+    x["psd_dual_sideband"],
+    x["psd_i"],
+    x["psd_q"],
+    x["freq_iq"],
+)
+
+
+plt.figure()
+plt.plot(np.fft.fftshift(freq_dsb),
+         np.fft.fftshift(psd_dsb), label="DSB")
+plt.plot(freq_iq, psd_i, label="I")
+plt.plot(freq_iq, psd_q, label="Q") # probably doesn't show
+plt.xlabel('Frequency (Hz)')
+plt.ylabel('Amp (dBc)')
+plt.legend()
+plt.grid(True)
+plt.tight_layout()
+
+# I had better be negligible
+assert all(psd_i < -300)
+
+# Q and DSB spectra are only allowed energy at DC
+assert all((psd_q < -300) | (np.abs(freq_iq) < 1))
+assert all((psd_dsb < -300) | (np.abs(freq_dsb) < 1))
+
+# magnitude 1 -> expect 0 dB
+assert max(psd_q) == pytest.approx(0, abs=1)
+assert max(psd_dsb) == pytest.approx(0, abs=1)
+```
+
+```python
+# Complex +Nyquist/2 signal
+x = _compute_spectrum(np.array([1, 0, -1, 0]*250),
+                      np.array([0, 1, 0, -1]*250),
+                      625e6 / (256 * 64 * 2**6), 6,
+                      scaling='ps', reference='absolute')
+
+(freq_dsb, psd_dsb, psd_i, psd_q, freq_iq) = (
+    x["freq_dsb"],
+    x["psd_dual_sideband"],
+    x["psd_i"],
+    x["psd_q"],
+    x["freq_iq"],
+)
+
+plt.figure()
+plt.plot(np.fft.fftshift(freq_dsb),
+         np.fft.fftshift(psd_dsb), label="DSB")
+plt.plot(freq_iq, psd_i, label="I")
+plt.plot(freq_iq, psd_q, label="Q") # probably doesn't show
+plt.xlabel('Frequency (Hz)')
+plt.ylabel('Amp (dBc)')
+plt.legend()
+plt.grid(True)
+plt.tight_layout()
+
+### TODO: magnitude and mask checks
+```
+
+```python
+
+```

--- a/test/test_calls.py
+++ b/test/test_calls.py
@@ -27,6 +27,7 @@ import pytest
 
 
 @pytest.mark.asyncio
+@pytest.mark.offline
 async def test_macro():
     @rfmux.macro(rfmux.CRS, register=True)
     async def macro_that_returns_serial_number(d):
@@ -46,6 +47,7 @@ async def test_macro():
 
 
 @pytest.mark.asyncio
+@pytest.mark.offline
 async def test_algorithm():
     @rfmux.algorithm(rfmux.CRS)
     async def algorithm_that_returns_serial_number(d):

--- a/test/test_schema.py
+++ b/test/test_schema.py
@@ -21,6 +21,7 @@ import pytest
 import textwrap
 
 
+@pytest.mark.offline
 def test_hardware_map_with_single_board():
     s = rfmux.load_session(
         """
@@ -32,6 +33,7 @@ def test_hardware_map_with_single_board():
     assert d.serial == "0024"
 
 
+@pytest.mark.offline
 def test_hardware_map_with_single_crate():
     s = rfmux.load_session(
         """
@@ -43,6 +45,8 @@ def test_hardware_map_with_single_crate():
     assert d.serial == "001"
 
 
+@pytest.mark.xfail
+@pytest.mark.offline
 def test_hardware_map_with_crate_slots_indexed_by_list():
     s = rfmux.load_session(
         """
@@ -76,6 +80,8 @@ def test_hardware_map_with_crate_slots_indexed_by_list():
     assert {c.serial, d1.crate.serial, d2.crate.serial, d3.crate.serial} == {"001"}
 
 
+@pytest.mark.xfail
+@pytest.mark.offline
 def test_hardware_map_with_crate_slots_indexed_by_dictionary():
     s = rfmux.load_session(
         """
@@ -98,6 +104,8 @@ def test_hardware_map_with_crate_slots_indexed_by_dictionary():
     assert c.slot[3].serial == "0026"
 
 
+@pytest.mark.xfail
+@pytest.mark.offline
 def test_hardware_map_with_wafer_and_resonator_csv(tmp_path):
     csvfile = tmp_path / "test.csv"
 
@@ -138,6 +146,8 @@ def test_hardware_map_with_wafer_and_resonator_csv(tmp_path):
     assert r2.wafer.name == "some_wafer"
 
 
+@pytest.mark.xfail
+@pytest.mark.offline
 def test_hardware_map_with_channel_mappings(tmp_path):
 
     # Create a CSV file describing a few Resonators. We'll load this below in

--- a/test/test_threads.py
+++ b/test/test_threads.py
@@ -18,9 +18,11 @@ storage.  This should give us a single Session object per thread.
 [1]: https://docs.sqlalchemy.org/en/20/orm/contextual.html#sqlalchemy.orm.scoped_session
 """
 
-import threading
+import pytest
 import rfmux
+import threading
 
+@pytest.mark.offline
 def test_are_sessions_distinct_between_threads():
     '''Check that threads each get their own underlying Session / HardwareMap'''
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,5 @@ deps =
     sqlalchemy2.0: SQLAlchemy>=2.0.29
 
 commands =
-    {envpython} -m pip install -U pip setuptools
-    {envpython} -m pip install -e .
-    {envpython} -m pytest
+    uv pip install -e .[dev]
+    uv run pytest -k offline


### PR DESCRIPTION
Here's the crashland - I've ported across most of the older QC tests and xfail'd the ones I haven't. There are two of these:

- test_dac_mixmodes
- test_adc_attenuation

A couple of reasons I think this was worth the hassle:

- Documentation products are no longer split between test code and report generation - all markup is generated when the tests are run
- It's now possible to assemble multiple pytest invocations into a single report. This is important because 
- Configuration (i.e. "high bank" vs "low bank") is now defined when pytest is invoked (using "-k" and pytest.mark), rather than requiring stdin/stdout interaction when the tests are run. This means we'll need to create a top-level script (in bash, or Python) that does the prompting instead.

I propose getting this merged after a review-in-principle, even though we're regressing on tests that formerly passed. QC was in work-in-progress status before and will remain that way for some time yet.