### PR TITLE
Periscope on windows

### DIFF
--- a/rfmux/core/mock_udp_streamer.py
+++ b/rfmux/core/mock_udp_streamer.py
@@ -110,8 +110,8 @@ class MockCRSUDPStreamer(threading.Thread):
                 self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 4_000_000)
 
                 if platform.system() == "Windows":
+                    print("Identfied as a windows machine while setting up socket")
                     try:
-                        print("Identfied as a windows machine while setting up socket")
                         self.socket.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 1)
                         self.socket.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF, socket.inet_aton("127.0.0.1"))
                     except:
@@ -121,6 +121,7 @@ class MockCRSUDPStreamer(threading.Thread):
                 # Bind multicast to loopback interface (lo) for local testing
                 # Using if_nametoindex to get the interface index for 'lo'  
                 else:
+                    print("Identfied as an Unix-like system, either Mac or Linux, will follow the socket protocol accordingly")
                     for iface in ("lo", "lo0"): 
                         # lo is for Linux and lo0 is for Mac 
                         try:

--- a/rfmux/core/mock_udp_streamer.py
+++ b/rfmux/core/mock_udp_streamer.py
@@ -12,6 +12,7 @@ import signal
 import atexit
 from datetime import datetime
 import numpy as np # For np.clip in generate_packet
+import platform
 
 # Import DfmuxPacket and related constants from streamer
 from ..streamer import (
@@ -107,30 +108,40 @@ class MockCRSUDPStreamer(threading.Thread):
                 
                 # Set socket send buffer size for performance
                 self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 4_000_000)
+
+                if platform.system() == "Windows":
+                    try:
+                        print("Identfied as a windows machine while setting up socket")
+                        self.socket.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 1)
+                        self.socket.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF, socket.inet_aton("127.0.0.1"))
+                    except:
+                        print("Issue setting up socket on windows")
+                    
                 
                 # Bind multicast to loopback interface (lo) for local testing
-                # Using if_nametoindex to get the interface index for 'lo'
-                for iface in ("lo", "lo0"): 
-                    # lo is for Linux and lo0 is for Mac 
-                    try:
-                        lo_index = socket.if_nametoindex(iface)
-                        # Use IP_MULTICAST_IF with the loopback address
-                        # Note: IP_MULTICAST_IF expects an IP address, not an interface index
-                        # For interface index, we'd use IPV6_MULTICAST_IF, but we're using IPv4
-                        # So we stick with the loopback IP address
-                        self.socket.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF, socket.inet_aton('127.0.0.1'))
-                        print(f"[UDP] Multicast bound to loopback interface ({iface}, index {lo_index})")
-                        break
-                    except OSError:
-                        continue
+                # Using if_nametoindex to get the interface index for 'lo'  
                 else:
-                    # Fallback if 'lo or lo0' interface not found (shouldn't happen on Linux or Mac)
-                    print("[UDP] Warning: Could not find 'lo' or 'lo0' interface")
-                    print("[UDP] Warning: The packets are now being launched on your network, rather than on the loopback interface")
-                    print("\nPlease implement the loopback interface with either 'lo' or 'lo0'")
-                    self.socket.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF, socket.inet_aton('0.0.0.0'))
-                
-                print(f"[UDP] Multicast socket initialized for {self.multicast_group}:{self.multicast_port}")
+                    for iface in ("lo", "lo0"): 
+                        # lo is for Linux and lo0 is for Mac 
+                        try:
+                            lo_index = socket.if_nametoindex(iface)
+                            # Use IP_MULTICAST_IF with the loopback address
+                            # Note: IP_MULTICAST_IF expects an IP address, not an interface index
+                            # For interface index, we'd use IPV6_MULTICAST_IF, but we're using IPv4
+                            # So we stick with the loopback IP address
+                            self.socket.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF, socket.inet_aton('127.0.0.1'))
+                            print(f"[UDP] Multicast bound to loopback interface ({iface}, index {lo_index})")
+                            break
+                        except OSError:
+                            continue
+                    else:
+                        # Fallback if 'lo or lo0' interface not found (shouldn't happen on Linux or Mac)
+                        print("[UDP] Warning: Could not find 'lo' or 'lo0' interface")
+                        print("[UDP] Warning: The packets are now being launched on your network, rather than on the loopback interface")
+                        print("\nPlease implement the loopback interface with either 'lo' or 'lo0'")
+                        self.socket.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF, socket.inet_aton('0.0.0.0'))
+                    
+                    print(f"[UDP] Multicast socket initialized for {self.multicast_group}:{self.multicast_port}")
             else:
                 # Create socket for unicast
                 self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)

--- a/rfmux/core/mock_udp_streamer.py
+++ b/rfmux/core/mock_udp_streamer.py
@@ -110,7 +110,6 @@ class MockCRSUDPStreamer(threading.Thread):
                 self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 4_000_000)
 
                 if platform.system() == "Windows":
-                    print("Identfied as a windows machine while setting up socket")
                     try:
                         self.socket.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 1)
                         self.socket.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF, socket.inet_aton("127.0.0.1"))
@@ -121,7 +120,6 @@ class MockCRSUDPStreamer(threading.Thread):
                 # Bind multicast to loopback interface (lo) for local testing
                 # Using if_nametoindex to get the interface index for 'lo'  
                 else:
-                    print("Identfied as an Unix-like system, either Mac or Linux, will follow the socket protocol accordingly")
                     for iface in ("lo", "lo0"): 
                         # lo is for Linux and lo0 is for Mac 
                         try:
@@ -139,7 +137,6 @@ class MockCRSUDPStreamer(threading.Thread):
                         # Fallback if 'lo or lo0' interface not found (shouldn't happen on Linux or Mac)
                         print("[UDP] Warning: Could not find 'lo' or 'lo0' interface")
                         print("[UDP] Warning: The packets are now being launched on your network, rather than on the loopback interface")
-                        print("\nPlease implement the loopback interface with either 'lo' or 'lo0'")
                         self.socket.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF, socket.inet_aton('0.0.0.0'))
                     
                     print(f"[UDP] Multicast socket initialized for {self.multicast_group}:{self.multicast_port}")

--- a/rfmux/streamer.py
+++ b/rfmux/streamer.py
@@ -7,6 +7,7 @@ import socket
 import struct
 import sys
 import warnings
+import platform
 
 # Constants
 STREAMER_PORT = 9876

--- a/rfmux/streamer.py
+++ b/rfmux/streamer.py
@@ -7,7 +7,6 @@ import socket
 import struct
 import sys
 import warnings
-import platform
 
 # Constants
 STREAMER_PORT = 9876

--- a/rfmux/tools/periscope/__main__.py
+++ b/rfmux/tools/periscope/__main__.py
@@ -43,7 +43,6 @@ import platform
 # have been removed as they are expected to be covered by 'from .utils import *'.
 
 if platform.system() == "Windows":
-    print("Identified as Windows system")
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 def main():

--- a/rfmux/tools/periscope/__main__.py
+++ b/rfmux/tools/periscope/__main__.py
@@ -38,8 +38,13 @@ from .mock_configuration_dialog import MockConfigurationDialog
 from .utils import *
 from .tasks import *
 from .ui import *
+import platform
 # Note: The original commented-out lines for QtWidgets and QIcon imports
 # have been removed as they are expected to be covered by 'from .utils import *'.
+
+if platform.system() == "Windows":
+    print("Identified as Windows system")
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 def main():
     """


### PR DESCRIPTION
Found the one line of code that "tricks" window to use it as loopback using 127 address. 

I think we already had a lot of relevant code already to set things up on windows, the only thing we were asking it to do is to find a loopback interface, but windows doesn't have one by default, hence that "if statement" basically opens the sender socket that aligns with the receiver sockets we need. 

In case of Linux and Mac they have specific interfaces, I kind of just asked window to make one. 

I will test it if I get my hands on another windows machine! 

You will need git bash to make it work, the installation steps for it are available in Windows README. The README suggests the use of uv for all python related stuff, in my case I used conda and made sure that I have access to my conda environment in my git bash. I can provide documentation for this as well if needed. 

It works on Linux and MacOS

The output looks like this - 
<img width="2555" height="1280" alt="Screenshot 2025-09-18 164712" src="https://github.com/user-attachments/assets/0ed42706-1abd-4292-ad61-3af11515638a" />
