### PR TITLE
fix(py-get-samples-and-update-noise-plot)

### DIFF
--- a/rfmux/algorithms/measurement/py_get_samples.py
+++ b/rfmux/algorithms/measurement/py_get_samples.py
@@ -319,13 +319,23 @@ async def py_get_samples(crs: CRS,
                 q_data = results["q"][c]
                 
                 # Calculate spectrum for this channel
-                d = spectrum_from_slow_tod(
-                    i_data, q_data, dec_stage,
-                    scaling=scaling,
-                    nperseg=nperseg if nperseg else num_samples,
-                    reference=reference,
-                    spectrum_cutoff=spectrum_cutoff
-                )
+                if reference == "absolute": #### since its in volts
+                    d = spectrum_from_slow_tod(
+                        i_data, q_data, dec_stage,
+                        scaling=scaling,
+                        nperseg=nperseg if nperseg else num_samples,
+                        reference=reference,
+                        spectrum_cutoff=spectrum_cutoff,
+                        input_units="volts"
+                    )
+                else:
+                    d = spectrum_from_slow_tod(
+                        i_data, q_data, dec_stage,
+                        scaling=scaling,
+                        nperseg=nperseg if nperseg else num_samples,
+                        reference=reference,
+                        spectrum_cutoff=spectrum_cutoff
+                    )
                 
                 # Store freq_iq, freq_dsb once
                 if spec_data["freq_iq"] is None:
@@ -345,13 +355,24 @@ async def py_get_samples(crs: CRS,
         else:
             i_data = results["i"]
             q_data = results["q"]
-            d = spectrum_from_slow_tod(
-                i_data, q_data, dec_stage,
-                scaling=scaling,
-                nperseg=nperseg if nperseg else num_samples,
-                reference=reference,
-                spectrum_cutoff=spectrum_cutoff
-            )
+            
+            if reference == "absolute": #### since its in volts
+                d = spectrum_from_slow_tod(
+                    i_data, q_data, dec_stage,
+                    scaling=scaling,
+                    nperseg=nperseg if nperseg else num_samples,
+                    reference=reference,
+                    spectrum_cutoff=spectrum_cutoff,
+                    input_units="volts"
+                )
+            else:
+                d = spectrum_from_slow_tod(
+                    i_data, q_data, dec_stage,
+                    scaling=scaling,
+                    nperseg=nperseg if nperseg else num_samples,
+                    reference=reference,
+                    spectrum_cutoff=spectrum_cutoff
+                )
             spec_data["freq_iq"] = d["freq_iq"].tolist()
             spec_data[f"{scaling}_i"] = d["psd_i"].tolist()
             spec_data[f"{scaling}_q"] = d["psd_q"].tolist()

--- a/rfmux/tools/periscope/detector_digest_dialog.py
+++ b/rfmux/tools/periscope/detector_digest_dialog.py
@@ -808,8 +808,12 @@ class DetectorDigestWindow(QtWidgets.QMainWindow):
     
             ###### First plot ######
             ts = self._get_relative_timestamps(self.spectrum_data['ts'], len(self.tod_i))
-            tod_i_volts = convert_roc_to_volts(np.array(self.tod_i))
-            tod_q_volts = convert_roc_to_volts(np.array(self.tod_q))
+            if self.reference == "relative":
+                tod_i_volts = convert_roc_to_volts(np.array(self.tod_i))
+                tod_q_volts = convert_roc_to_volts(np.array(self.tod_q))
+            else:
+                tod_i_volts = np.array(self.tod_i)
+                tod_q_volts = np.array(self.tod_q) ##### it is already converted to volts in spectrum_from_slow_tod_function for "absolute"
     
             if self.mean_subtract_enabled:
                 tod_i_volts = tod_i_volts - np.mean(tod_i_volts)


### PR DESCRIPTION
 when reference is "absolute" the value is already in volts, it was converting again, its removed now