### PR TITLE
Firmware r1.7.0

### DIFF
--- a/firmware/.gitattributes
+++ b/firmware/.gitattributes
@@ -1,7 +1,6 @@
+*.bin filter=lfs diff=lfs merge=lfs -text
+*.bz2 filter=lfs diff=lfs merge=lfs -text
+*.elf filter=lfs diff=lfs merge=lfs -text
+*.gz filter=lfs diff=lfs merge=lfs -text
 parser filter=lfs diff=lfs merge=lfs -text
-sdcard.img.bz2 filter=lfs diff=lfs merge=lfs -text
-boot.bin filter=lfs diff=lfs merge=lfs -text
 u-boot.itb filter=lfs diff=lfs merge=lfs -text
-fsbl.elf filter=lfs diff=lfs merge=lfs -text
-rootfs.ext4.bz2 filter=lfs diff=lfs merge=lfs -text
-parser_src.tar.gz filter=lfs diff=lfs merge=lfs -text

--- a/firmware/CHANGES
+++ b/firmware/CHANGES
@@ -1,5 +1,35 @@
 # Changelog
 
+# r1.7.0rc1 - 2026-07-03
+
+This is a major update, and REQUIRES an accompanying bootloader upgrade as well.
+You will need one of the following:
+
+- Vivado/Vitis installation (2025.01) with a working "program_flash" command, OR
+- A "Flat Mark" / "Flat Stanley" machine with the above pre-installed, which t0
+  can ship to you.
+
+New features:
+
+- "fwdiscover" upgrade flow, which should obviate the above hassle in future
+  bootloader revisions. You will be able to re-image both the non-removable
+  (bootloader) flash and the removable (filesystem/SD card) flash over the
+  network.
+
+- Major software build re-organization, using Yocto instead of Buildroot. This
+  brings us in line with most other users of the RFSoC (notable exclusions:
+  PYNQ, which grafts their source code on top of AMD/Canonical's Ubuntu
+  distribution). We love Buildroot but vendor momentum surrounding Yocto, plus
+  the larger user base, makes Yocto a better long-term option.
+
+- 100G streaming interface: it is now possible to stream up to 1024 channels
+  (on only one module!) at 2.44 Gsps, allowing real-time high-bandwidth,
+  high-channel-count streaming modes. We anticipate the software side of this
+  work (Linux-only) will also land in rfmux in the near future.
+
+We expect this release will take some time to roll out - if you are interested,
+please get in touch and we'll make sure you have the information you need.
+
 # r1.6.1 - 2026-07-03
 
 - set_amplitude_limit: correct unit scaling. The previous conversion resulted

--- a/firmware/CHANGES
+++ b/firmware/CHANGES
@@ -9,6 +9,8 @@ You will need one of the following:
 - A "Flat Mark" / "Flat Stanley" machine with the above pre-installed, which t0
   can ship to you.
 
+See fmrware/r1.7.0rc1/README for details.
+
 New features:
 
 - "fwdiscover" upgrade flow, which should obviate the above hassle in future

--- a/firmware/r1.7.0rc1/README
+++ b/firmware/r1.7.0rc1/README
@@ -1,0 +1,27 @@
+Firmware r1.7.0
+===============
+
+Upgrading from (firmware < 1.7.0) to (firmware >= 1.7.0) requires an upgrade to
+the SPI-flash bootloader. This is (hopefully) only a hassle once -- in future,
+it will be possible to do this step automatically via a Python script. However,
+if you are crossing the 1.7.0 boundary for the first time, you'll have to take
+extra steps.
+
+If you have Vivado 2025.1 installed, here is the necessary step:
+
+1. Ensure firmware files are actually present (and not just git-lfs placeholders)
+
+	$ git lfs pull --exclude= .
+
+2. Set up the Vivado execution environment:
+
+	$ source /opt/xilinx/2025.1/Vivado/settings64.sh
+
+3. With the board powered up and the SD card removed, run:
+
+	$ program_flash -f boot.bin -fsbl fsbl.elf -flash_type qspi-x8-dual_parallel
+
+Please contact us (gsmecher@t0.technology) with questions. We have prepared two
+portable computers ("Flat Mark" and "Flat Stanley") with the necessary software
+pre-installed; it's our intention to ship these to sites where people are
+unfamiliar with Vivado.

--- a/firmware/r1.7.0rc1/boot.bin
+++ b/firmware/r1.7.0rc1/boot.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4649ab3776cbefc05bddb4200e39c43670702d84cc5a0a6f05fd7c93d4559ba6
+size 1884872

--- a/firmware/r1.7.0rc1/fsbl.elf
+++ b/firmware/r1.7.0rc1/fsbl.elf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4be2dada89d0199ad991f9d81575958ae534d1c9337f137180fdb495ef007fbc
+size 731648

--- a/firmware/r1.7.0rc1/rootfs.wic.gz
+++ b/firmware/r1.7.0rc1/rootfs.wic.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a75eae74a1362b7a702d93da63dc0d2948ffffbfda8185146229ba33e6e55271
+size 249688568


### PR DESCRIPTION
This is the first release of Yocto-based firmware, and also includes

* 100GbE streaming
* fwdiscover-based firmware uploads via remote U-Boot

It is otherwise intended to be feature-equivalent.

The release flow will go as follows:

- The initial version is a "rc1" ("release candidate 1"), which we'll iterate on as we discover bugs
- eventually, we'll promote the release to r1.7.0 and merge it

The Flat Stanley / Flat Mark / upgrade roll-out can proceed from there.